### PR TITLE
Kitchen v2：可正式驗收的團膳菜單、配方與採購叫貨

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Never commit the real values below.
+
+# Supabase PostgreSQL connection string (server-side only)
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/postgres
+
+# Generate a long random value for production
+SECRET_KEY=replace-with-a-long-random-secret
+
+# Set at least one admin password
+ADMIN_HR_PASSWORD=replace-with-a-strong-password
+ADMIN_MGR_PASSWORD=replace-with-a-strong-password
+
+# Production safety switches
+PRODUCTION=1
+AUTO_CREATE_DB=0
+KITCHEN_CSRF_ENABLED=1
+ADMIN_SESSION_HOURS=12
+
+# Existing punch settings can keep their current deployment values
+PUNCH_GATE_TTL_SEC=120
+PUNCH_TOKEN_TTL_SEC=120
+PUNCH_BIND_IP=0
+PUNCH_BIND_UA=1
+PUNCH_GEOFENCE_ENABLED=1
+PUNCH_ALLOW_RADIUS_M=500
+PUNCH_REQUIRE_ACCURACY_M=250

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,26 @@
-# Python 
+# Python
 __pycache__/
 *.pyc
+.pytest_cache/
 
 # Virtual env
 venv/
-.env/
+.venv/
 
-# Database / Excel
-#attendance.db
+# Secrets / local environment
+.env
+.env.*
+!.env.example
+
+# Local databases / office exports
+attendance.db
+*.db-journal
+*.sqlite
+*.sqlite3
 *.xlsx
 !static/薪資計算範本.xlsx
+
+# OS / editor
+.DS_Store
+.vscode/
+.idea/

--- a/KITCHEN_DEPLOY.md
+++ b/KITCHEN_DEPLOY.md
@@ -1,0 +1,131 @@
+# Kitchen v2 deployment / verification
+
+`kitchen-v2` is designed to keep the existing attendance models (`employee`, `checkin`) untouched and add the group-meal workflow under `kitchen_*` tables.
+
+## 1. Before production
+
+Do not merge or deploy until the branch passes:
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m compileall -q app.py config.py models.py blueprints tests
+pytest -q tests/test_kitchen.py
+```
+
+Browser verification should cover at least 375×812, 430×932, 768×1024 and 1440×900.
+
+## 2. Required production environment variables
+
+Use the deployment platform's secret/environment settings. Do not put real values in `.env.example` or GitHub.
+
+Required:
+
+- `DATABASE_URL`: Supabase PostgreSQL server connection string used by Flask/SQLAlchemy.
+- `SECRET_KEY`: long random secret.
+- `ADMIN_HR_PASSWORD` and/or `ADMIN_MGR_PASSWORD`: strong admin password(s).
+- `PRODUCTION=1`
+- `AUTO_CREATE_DB=0`
+- `KITCHEN_CSRF_ENABLED=1`
+
+When `PRODUCTION=1`, the app intentionally refuses to start if `SECRET_KEY` or all admin passwords are missing, or if kitchen CSRF is disabled.
+
+## 3. Supabase / migration warning
+
+This repository has historical Alembic migration drift around old attendance table names. Therefore **do not blindly run `flask db migrate` against production Supabase**.
+
+The manually reviewed migration is:
+
+`migrations/versions/kitchen20260813_prod.py`
+
+It is intentionally written to touch only these tables:
+
+- `kitchen_school`
+- `kitchen_supplier`
+- `kitchen_ingredient`
+- `kitchen_recipe`
+- `kitchen_recipe_ingredient`
+- `kitchen_menu_plan`
+- `kitchen_menu_plan_item`
+- `kitchen_menu_assignment`
+- `kitchen_purchase_order`
+- `kitchen_purchase_order_item`
+
+It must never drop, rename or alter `employee` / `checkin`.
+
+### Recommended release procedure
+
+1. Clone the current production database to a staging/test PostgreSQL project when possible.
+2. Inspect `alembic_version` and current table names first.
+3. Confirm the staging database already has the same attendance schema used by production.
+4. Run the reviewed migration on staging.
+5. Re-run the kitchen regression tests against staging.
+6. Verify attendance/punch still works.
+7. Only then apply the exact same reviewed migration to production.
+
+If the production database has no `alembic_version` table, do not guess or stamp it without first inspecting the schema. Ask for a schema dump / table list and decide the correct stamp point before running Alembic.
+
+## 4. Business-flow acceptance test
+
+Use this exact test case:
+
+- School: 內小
+- Headcount: 801
+- Supplier: 測試肉品
+- Ingredient: 骨腿丁
+- Purchase unit: kg
+- `grams_per_purchase_unit = 1000`
+- Price: 82 / kg
+- Recipe: 南洋綠咖哩雞
+- Serving output: 95 g/person
+- AP ingredient amount: 88 g/person
+
+Expected demand:
+
+`88 × 801 = 70,488 g = 70.488 kg`
+
+Expected raw-material cost at 82/kg:
+
+`70.488 × 82 = 5,780.016`
+
+The 95 g serving-output field must not be used to calculate bone-in chicken procurement.
+
+Then add a second school with 586 diners. Expected chicken demand:
+
+`(801 + 586) × 88 = 122,056 g = 122.056 kg`
+
+## 5. Purchase snapshot acceptance test
+
+1. Generate a draft purchase order.
+2. Confirm the order while chicken is 82/kg and the recipe uses 88 g/person.
+3. Change the ingredient master price to 90/kg.
+4. Change the recipe AP amount to 90 g/person.
+5. Open the already-confirmed historical order.
+
+The confirmed order must still show its original required grams, original 82 price snapshot and original amount. It must not be recalculated from current master data.
+
+## 6. Mobile / desktop acceptance
+
+Kitchen templates load `static/kitchen_mobile.css` and `static/kitchen_ui.js` directly. The old response-injection approach has been removed.
+
+Check:
+
+- phone bottom navigation and safe-area spacing;
+- 44–48 px touch targets;
+- iPhone inputs use 16 px text to prevent Safari auto-zoom;
+- wide tables scroll horizontally on phones;
+- desktop retains multi-column cards and normal tables;
+- print view hides navigation;
+- attendance pages do not load kitchen CSS/JS.
+
+## 7. Security notes
+
+- Old hard-coded admin passwords were removed from current branch code. If any old password was used in real life, treat it as compromised and replace it.
+- `SECRET_KEY` is no longer a fixed public string.
+- `/admin/*` is login-protected; `/punch` remains outside that guard.
+- Kitchen mutation POSTs use a session CSRF token.
+- `.env` and local SQLite files are ignored for future commits.
+- The repository history may still contain previously committed secrets or databases; `.gitignore` does not erase Git history. Review history separately before treating the repository as clean for sensitive production use.
+
+## 8. Do not merge automatically
+
+Keep work on `kitchen-v2` until automated tests plus browser tests pass. Merge to `main` should be an explicit final decision after review.

--- a/KITCHEN_DEPLOY.md
+++ b/KITCHEN_DEPLOY.md
@@ -29,40 +29,51 @@ Required:
 
 When `PRODUCTION=1`, the app intentionally refuses to start if `SECRET_KEY` or all admin passwords are missing, or if kitchen CSRF is disabled.
 
-## 3. Supabase / migration warning
+## 3. Supabase / schema warning
 
-This repository has historical Alembic migration drift around old attendance table names. Therefore **do not blindly run `flask db migrate` against production Supabase**.
+This repository has historical Alembic migration drift around old attendance table names. Therefore **do not blindly run `flask db migrate` or a full historical `flask db upgrade` against production Supabase**.
 
-The manually reviewed migration is:
+Two kitchen-only tools are provided:
+
+- `scripts/bootstrap_kitchen_schema.py`
+- `migrations/versions/kitchen20260813_prod.py`
+
+Both are intentionally limited to `kitchen_*` tables and must never drop, rename or alter `employee` / `checkin`.
+
+### Case A: production has no kitchen_* tables yet
+
+This is the safest initial deployment path.
+
+After setting the real server-side `DATABASE_URL` and production secrets, run:
+
+```bash
+python scripts/bootstrap_kitchen_schema.py
+```
+
+The script creates only the final kitchen tables in dependency order. It does not call `db.create_all()` for attendance tables.
+
+If it finds an existing kitchen table whose columns do not match the final model, it **refuses to alter it** and exits. This is intentional fail-closed behavior.
+
+### Case B: production/staging already has older MVP kitchen_* tables
+
+Do not use the bootstrap script to silently patch them. Use a staging clone first and review/apply:
 
 `migrations/versions/kitchen20260813_prod.py`
 
-It is intentionally written to touch only these tables:
-
-- `kitchen_school`
-- `kitchen_supplier`
-- `kitchen_ingredient`
-- `kitchen_recipe`
-- `kitchen_recipe_ingredient`
-- `kitchen_menu_plan`
-- `kitchen_menu_plan_item`
-- `kitchen_menu_assignment`
-- `kitchen_purchase_order`
-- `kitchen_purchase_order_item`
-
-It must never drop, rename or alter `employee` / `checkin`.
+The reviewed migration can add the missing production columns/tables while remaining kitchen-only.
 
 ### Recommended release procedure
 
-1. Clone the current production database to a staging/test PostgreSQL project when possible.
-2. Inspect `alembic_version` and current table names first.
-3. Confirm the staging database already has the same attendance schema used by production.
-4. Run the reviewed migration on staging.
-5. Re-run the kitchen regression tests against staging.
-6. Verify attendance/punch still works.
-7. Only then apply the exact same reviewed migration to production.
+1. Inspect the current Supabase table list and `alembic_version` first.
+2. Prefer a staging/test Supabase project cloned from production.
+3. Confirm staging attendance tables match production.
+4. If no kitchen tables exist, test `python scripts/bootstrap_kitchen_schema.py` on staging.
+5. If older kitchen tables exist, test the reviewed kitchen-only migration on staging instead.
+6. Run the full kitchen regression tests.
+7. Verify existing attendance/admin pages and `/punch` still work.
+8. Only then repeat the same kitchen-only schema operation on production.
 
-If the production database has no `alembic_version` table, do not guess or stamp it without first inspecting the schema. Ask for a schema dump / table list and decide the correct stamp point before running Alembic.
+If production has no `alembic_version` table, do not guess or stamp it without inspecting the schema first.
 
 ## 4. Business-flow acceptance test
 

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def create_app() -> Flask:
     app.register_blueprint(punch_bp)              # /punch
 
     # ── 團膳頁專用 responsive UI ──
-    # 只對 /admin/order-tool 注入 CSS，不影響既有打卡、薪資等頁面。
+    # 只對 /admin/order-tool 注入 CSS / JS，不影響既有打卡、薪資等頁面。
     @app.after_request
     def inject_kitchen_responsive_ui(response):
         if (
@@ -47,12 +47,17 @@ def create_app() -> Flask:
             html = response.get_data(as_text=True)
             css_tag = (
                 '<link rel="stylesheet" '
-                'href="/static/kitchen_mobile.css?v=2">'
+                'href="/static/kitchen_mobile.css?v=3">'
             )
+            js_tag = '<script src="/static/kitchen_ui.js?v=1" defer></script>'
+
             if "</head>" in html and "kitchen_mobile.css" not in html:
                 html = html.replace("</head>", f"{css_tag}</head>", 1)
-                response.set_data(html)
-                response.headers["Content-Length"] = len(response.get_data())
+            if "</body>" in html and "kitchen_ui.js" not in html:
+                html = html.replace("</body>", f"{js_tag}</body>", 1)
+
+            response.set_data(html)
+            response.headers["Content-Length"] = len(response.get_data())
         return response
 
     # ── 首頁導向 ──

--- a/app.py
+++ b/app.py
@@ -18,9 +18,11 @@ from blueprints.import_employees import import_bp
 from blueprints.order_tool import order_bp
 
 
-def create_app() -> Flask:
+def create_app(config_overrides=None) -> Flask:
     app = Flask(__name__)
     app.config.from_object(Config)
+    if config_overrides:
+        app.config.update(config_overrides)
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
     db.init_app(app)

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 import flask.blueprints   # 這行一定放最上面
 
 import os
-from flask import Flask, redirect, url_for
+from flask import Flask, redirect, url_for, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 from config     import Config
 from extensions import db, migrate
@@ -34,6 +34,26 @@ def create_app() -> Flask:
     app.register_blueprint(import_bp, url_prefix="/admin")
     app.register_blueprint(order_bp, url_prefix="/admin/order-tool")
     app.register_blueprint(punch_bp)              # /punch
+
+    # ── 團膳頁專用 responsive UI ──
+    # 只對 /admin/order-tool 注入 CSS，不影響既有打卡、薪資等頁面。
+    @app.after_request
+    def inject_kitchen_responsive_ui(response):
+        if (
+            request.path.startswith("/admin/order-tool")
+            and response.mimetype == "text/html"
+            and response.status_code < 400
+        ):
+            html = response.get_data(as_text=True)
+            css_tag = (
+                '<link rel="stylesheet" '
+                'href="/static/kitchen_mobile.css?v=2">'
+            )
+            if "</head>" in html and "kitchen_mobile.css" not in html:
+                html = html.replace("</head>", f"{css_tag}</head>", 1)
+                response.set_data(html)
+                response.headers["Content-Length"] = len(response.get_data())
+        return response
 
     # ── 首頁導向 ──
     @app.route("/")

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 import flask.blueprints
 
 import os
-from flask import Flask, redirect, url_for
+from flask import Flask, redirect, request, session, url_for
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import Config
@@ -23,6 +23,16 @@ def create_app(config_overrides=None) -> Flask:
     app.config.from_object(Config)
     if config_overrides:
         app.config.update(config_overrides)
+
+    # 正式環境 fail closed：少了秘密或管理密碼就不要假裝安全上線。
+    if app.config.get("PRODUCTION", False):
+        if not app.config.get("SECRET_KEY_CONFIGURED", False):
+            raise RuntimeError("PRODUCTION=1 時必須設定 SECRET_KEY。")
+        if not (app.config.get("ADMIN_HR_PASSWORD") or app.config.get("ADMIN_MGR_PASSWORD")):
+            raise RuntimeError("PRODUCTION=1 時至少要設定一組管理後台密碼。")
+        if not app.config.get("KITCHEN_CSRF_ENABLED", True):
+            raise RuntimeError("PRODUCTION=1 時不可關閉 KITCHEN_CSRF_ENABLED。")
+
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
     db.init_app(app)
@@ -35,6 +45,14 @@ def create_app(config_overrides=None) -> Flask:
     app.register_blueprint(import_bp, url_prefix="/admin")
     app.register_blueprint(order_bp, url_prefix="/admin/order-tool")
     app.register_blueprint(punch_bp)
+
+    @app.before_request
+    def protect_admin_pages():
+        # /punch 不在 /admin 下，因此既有打卡流程不受影響。
+        if request.path.startswith("/admin") and request.path not in {"/admin/login", "/admin/logout"}:
+            if not session.get("role"):
+                return redirect(url_for("auth.login", next=request.full_path.rstrip("?")))
+        return None
 
     @app.route("/")
     def home():

--- a/app.py
+++ b/app.py
@@ -1,18 +1,19 @@
 # --- 強制先載入官方 Blueprint 定義（防止覆寫）---
-import flask.blueprints   # 這行一定放最上面
+import flask.blueprints
 
 import os
-from flask import Flask, redirect, url_for, request
+from flask import Flask, redirect, url_for
 from werkzeug.middleware.proxy_fix import ProxyFix
-from config     import Config
+
+from config import Config
 from extensions import db, migrate
 
 # 藍圖
-from blueprints.auth      import auth_bp
-from blueprints.punch     import punch_bp
-from blueprints.employees       import emp_bp
-from blueprints.records         import rec_bp
-from blueprints.export          import exp_bp
+from blueprints.auth import auth_bp
+from blueprints.punch import punch_bp
+from blueprints.employees import emp_bp
+from blueprints.records import rec_bp
+from blueprints.export import exp_bp
 from blueprints.import_employees import import_bp
 from blueprints.order_tool import order_bp
 
@@ -22,59 +23,32 @@ def create_app() -> Flask:
     app.config.from_object(Config)
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-    # ── 初始化 ORM / Migrate ──
     db.init_app(app)
     migrate.init_app(app, db)
 
-    # ── 註冊藍圖 ──
     app.register_blueprint(auth_bp, url_prefix="/admin")
-    app.register_blueprint(emp_bp,  url_prefix="/admin")
-    app.register_blueprint(rec_bp,  url_prefix="/admin")
-    app.register_blueprint(exp_bp,  url_prefix="/admin")
+    app.register_blueprint(emp_bp, url_prefix="/admin")
+    app.register_blueprint(rec_bp, url_prefix="/admin")
+    app.register_blueprint(exp_bp, url_prefix="/admin")
     app.register_blueprint(import_bp, url_prefix="/admin")
     app.register_blueprint(order_bp, url_prefix="/admin/order-tool")
-    app.register_blueprint(punch_bp)              # /punch
+    app.register_blueprint(punch_bp)
 
-    # ── 團膳頁專用 responsive UI ──
-    # 只對 /admin/order-tool 注入 CSS / JS，不影響既有打卡、薪資等頁面。
-    @app.after_request
-    def inject_kitchen_responsive_ui(response):
-        if (
-            request.path.startswith("/admin/order-tool")
-            and response.mimetype == "text/html"
-            and response.status_code < 400
-        ):
-            html = response.get_data(as_text=True)
-            css_tag = (
-                '<link rel="stylesheet" '
-                'href="/static/kitchen_mobile.css?v=3">'
-            )
-            js_tag = '<script src="/static/kitchen_ui.js?v=1" defer></script>'
-
-            if "</head>" in html and "kitchen_mobile.css" not in html:
-                html = html.replace("</head>", f"{css_tag}</head>", 1)
-            if "</body>" in html and "kitchen_ui.js" not in html:
-                html = html.replace("</body>", f"{js_tag}</body>", 1)
-
-            response.set_data(html)
-            response.headers["Content-Length"] = len(response.get_data())
-        return response
-
-    # ── 首頁導向 ──
     @app.route("/")
     def home():
         return redirect(url_for("punch.qrcode_view"))
 
-    # ── ★ 第一次啟動自動建立所有資料表 ──
-    with app.app_context():
-        db.create_all()          # 如果已存在資料表則忽略，不會覆寫
-        
+    # 本機 SQLite / 明確指定的測試環境可自動建表。
+    # 正式 Supabase/PostgreSQL 預設關閉，應由 migration 管理 schema。
+    if app.config.get("AUTO_CREATE_DB", False):
+        with app.app_context():
+            db.create_all()
+
     return app
 
 
-# ────────────────────────── 本機 / 雲端啟動點 ──────────────────────────
 if __name__ == "__main__":
-    # 雲端平台（Render、Railway…）會把埠號放在 PORT 環境變數
+    app = create_app()
     port = int(os.environ.get("PORT", 5000))
-    # 正式環境建議把 debug 關掉，以免洩漏 Stack Trace
-    create_app().run(host="0.0.0.0", port=port, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "0") == "1" and not app.config.get("PRODUCTION", False)
+    app.run(host="0.0.0.0", port=port, debug=debug)

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -36,9 +36,10 @@ def _safe_next(value: str | None) -> str | None:
 
 @auth_bp.route("/login", methods=["GET", "POST"])
 def login():
-    err = ""
+    error = ""
     passwords = _passwords()
-    configured = any(passwords.values())
+    configured_roles = [(role, "人資" if role == "hr" else "主管") for role, pw in passwords.items() if pw]
+    configured = bool(configured_roles)
     next_url = _safe_next(request.args.get("next") or request.form.get("next"))
 
     if request.method == "POST":
@@ -52,33 +53,30 @@ def login():
             session.permanent = True
             return redirect(next_url or "/admin/")
 
-        err = "<p style='color:#b42318'>帳號角色或密碼錯誤。</p>"
-
-    options = "".join(
-        f'<option value="{role}">{"人資" if role == "hr" else "主管"}</option>'
-        for role, password in passwords.items()
-        if password
-    )
+        error = "帳號角色或密碼錯誤。"
 
     if not configured:
-        err = (
-            "<p style='color:#b42318'>管理密碼尚未設定。請在部署環境設定 "
-            "ADMIN_HR_PASSWORD 或 ADMIN_MGR_PASSWORD。</p>"
-        )
+        error = "管理密碼尚未設定。請在部署環境設定 ADMIN_HR_PASSWORD 或 ADMIN_MGR_PASSWORD。"
 
-    disabled = "disabled" if not configured else ""
-    hidden_next = f'<input type="hidden" name="next" value="{next_url}">' if next_url else ""
-
+    template = f"""<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">{CSS}</head><body>
+    <h2>管理登入</h2>
+    {{% if error %}}<p style="color:#b42318">{{{{ error }}}}</p>{{% endif %}}
+    <form method="post">
+      {{% if next_url %}}<input type="hidden" name="next" value="{{{{ next_url }}}}">{{% endif %}}
+      <select name="role" {{% if not configured %}}disabled{{% endif %}}>
+        {{% for value, label in roles %}}<option value="{{{{ value }}}}">{{{{ label }}}}</option>{{% endfor %}}
+      </select><br>
+      <input type="password" name="pw" autocomplete="current-password" required {{% if not configured %}}disabled{{% endif %}}><br>
+      <button {{% if not configured %}}disabled{{% endif %}}>登入</button>
+    </form>
+    <p><a href="/">回首頁</a></p></body></html>"""
     return render_template_string(
-        f"""<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">{CSS}</head><body>
-        <h2>管理登入</h2>{err}
-        <form method="post">
-          {hidden_next}
-          <select name="role" {disabled}>{options}</select><br>
-          <input type="password" name="pw" autocomplete="current-password" required {disabled}><br>
-          <button {disabled}>登入</button>
-        </form>
-        <p><a href="/">回首頁</a></p></body></html>"""
+        template,
+        error=error,
+        next_url=next_url,
+        roles=configured_roles,
+        configured=configured,
     )
 
 

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -1,34 +1,98 @@
-from flask import Blueprint, render_template_string, request, session, redirect, url_for, abort
+from secrets import compare_digest
+from urllib.parse import urlparse
+
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    redirect,
+    render_template_string,
+    request,
+    session,
+    url_for,
+)
+
 from . import CSS
 
-PASSWORDS = {"hr": "hr1234", "mgr": "mgr1234"}
 
 auth_bp = Blueprint("auth", __name__)
 
-@auth_bp.route("/login", methods=["GET","POST"])
-def login():
-    err=""
-    if request.method=="POST":
-        role = request.form["role"]
-        pw   = request.form["pw"]
-        if role in PASSWORDS and pw == PASSWORDS[role]:
-            session["role"]=role
-            return redirect("/admin/")
-        err="<p style='color:red'>錯誤</p>"
-    opt = "".join(f"<option value={r}>{'人資' if r=='hr' else '主管'}</option>"
-                  for r in PASSWORDS)
-    return render_template_string(f"""<!doctype html><html><head>{CSS}</head><body>
-    <h2>管理登入</h2>{err}
-    <form method=post>
-      <select name=role>{opt}</select><br>
-      <input type=password name=pw required><br>
-      <button>登入</button>
-    </form>
-    <p><a href="/">回首頁</a></p></body></html>""")
 
-def require(role):
-    r=session.get("role")
-    if not r:             # 未登入
-        return redirect("/admin/login")
-    if role=="hr" and r!="hr":
+def _passwords() -> dict[str, str]:
+    return {
+        "hr": current_app.config.get("ADMIN_HR_PASSWORD", ""),
+        "mgr": current_app.config.get("ADMIN_MGR_PASSWORD", ""),
+    }
+
+
+def _safe_next(value: str | None) -> str | None:
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc or not value.startswith("/"):
+        return None
+    return value
+
+
+@auth_bp.route("/login", methods=["GET", "POST"])
+def login():
+    err = ""
+    passwords = _passwords()
+    configured = any(passwords.values())
+    next_url = _safe_next(request.args.get("next") or request.form.get("next"))
+
+    if request.method == "POST":
+        role = request.form.get("role", "")
+        pw = request.form.get("pw", "")
+        expected = passwords.get(role, "")
+
+        if expected and compare_digest(pw, expected):
+            session.clear()
+            session["role"] = role
+            session.permanent = True
+            return redirect(next_url or "/admin/")
+
+        err = "<p style='color:#b42318'>帳號角色或密碼錯誤。</p>"
+
+    options = "".join(
+        f'<option value="{role}">{"人資" if role == "hr" else "主管"}</option>'
+        for role, password in passwords.items()
+        if password
+    )
+
+    if not configured:
+        err = (
+            "<p style='color:#b42318'>管理密碼尚未設定。請在部署環境設定 "
+            "ADMIN_HR_PASSWORD 或 ADMIN_MGR_PASSWORD。</p>"
+        )
+
+    disabled = "disabled" if not configured else ""
+    hidden_next = f'<input type="hidden" name="next" value="{next_url}">' if next_url else ""
+
+    return render_template_string(
+        f"""<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">{CSS}</head><body>
+        <h2>管理登入</h2>{err}
+        <form method="post">
+          {hidden_next}
+          <select name="role" {disabled}>{options}</select><br>
+          <input type="password" name="pw" autocomplete="current-password" required {disabled}><br>
+          <button {disabled}>登入</button>
+        </form>
+        <p><a href="/">回首頁</a></p></body></html>"""
+    )
+
+
+@auth_bp.route("/logout", methods=["GET", "POST"])
+def logout():
+    session.clear()
+    return redirect(url_for("auth.login"))
+
+
+def require(role=None):
+    """相容既有呼叫方式：無登入回登入頁；role='hr' 時只允許 HR。"""
+    current_role = session.get("role")
+    if not current_role:
+        return redirect(url_for("auth.login", next=request.path))
+    if role == "hr" and current_role != "hr":
         abort(403)
+    return None

--- a/blueprints/order_tool.py
+++ b/blueprints/order_tool.py
@@ -1,7 +1,7 @@
 """團膳菜單 / 配方 / 採購叫貨正式模組。
 
 核心流程：
-Recipe BOM（每人 AP 克數）→ 中央菜單 → 學校人數
+Recipe BOM（每人 AP 數量，可用 g 或 個）→ 中央菜單 → 學校人數
 → 食材需求彙總 → 供應商採購草稿 → 人工調整 → Confirm snapshot。
 """
 
@@ -39,12 +39,12 @@ from models import (
     KitchenSupplier,
 )
 
-
 order_bp = Blueprint("order_tool", __name__)
 
 CATEGORIES = ("主食", "主菜", "副菜", "青菜", "湯品", "點心", "其他")
 MEAL_TYPES = ("早餐", "午餐", "晚餐", "點心")
 PURCHASE_UNITS = ("kg", "箱", "包", "斤", "瓶", "個", "袋", "桶")
+BASE_UNITS = ("g", "個")
 WEEKDAY_LABELS = ("週一", "週二", "週三", "週四", "週五", "週六", "週日")
 
 
@@ -65,7 +65,6 @@ def _csrf_token() -> str:
 def _protect_kitchen():
     if not session.get("role"):
         return redirect(url_for("auth.login", next=request.full_path.rstrip("?")))
-
     if request.method == "POST" and current_app.config.get("KITCHEN_CSRF_ENABLED", True):
         expected = session.get("_kitchen_csrf", "")
         received = request.form.get("_csrf_token", "")
@@ -89,15 +88,17 @@ def _template_helpers():
         "recipe_total_g": _recipe_total_g,
         "component_cost": _component_cost,
         "trim_decimal": _trim_decimal,
+        "base_unit_label": _base_unit_label,
+        "required_display": _required_display,
     }
 
 
 def _status_label(status: str) -> str:
-    return {
-        "draft": "草稿",
-        "confirmed": "已確認",
-        "cancelled": "已取消",
-    }.get(status, status or "-")
+    return {"draft": "草稿", "confirmed": "已確認", "cancelled": "已取消"}.get(status, status or "-")
+
+
+def _base_unit_label(ingredient: KitchenIngredient) -> str:
+    return ingredient.base_unit or "g"
 
 
 def _decimal(raw, *, default=None) -> Decimal | None:
@@ -105,9 +106,7 @@ def _decimal(raw, *, default=None) -> Decimal | None:
         return default
     try:
         value = Decimal(str(raw).strip())
-        if not value.is_finite():
-            return default
-        return value
+        return value if value.is_finite() else default
     except (InvalidOperation, ValueError):
         return default
 
@@ -129,15 +128,19 @@ def _date(raw, *, default=None) -> date | None:
 
 
 def _recipe_total_g(recipe: KitchenRecipe) -> Decimal:
-    return sum((x.grams_per_person or Decimal("0") for x in recipe.ingredients), Decimal("0"))
+    """只加總 g 型食材，避免把 1 個直接誤當 1g 加進總生料重量。"""
+    return sum(
+        (x.grams_per_person or Decimal("0") for x in recipe.ingredients if (x.ingredient.base_unit or "g") == "g"),
+        Decimal("0"),
+    )
 
 
 def _component_cost(component: KitchenRecipeIngredient) -> Decimal:
     ing = component.ingredient
-    grams_per_unit = ing.grams_per_purchase_unit or Decimal("0")
-    if grams_per_unit <= 0:
+    units_per_purchase = ing.grams_per_purchase_unit or Decimal("0")
+    if units_per_purchase <= 0:
         return Decimal("0")
-    return (component.grams_per_person or Decimal("0")) / grams_per_unit * (ing.unit_price or Decimal("0"))
+    return (component.grams_per_person or Decimal("0")) / units_per_purchase * (ing.unit_price or Decimal("0"))
 
 
 def _recipe_cost(recipe: KitchenRecipe) -> Decimal:
@@ -156,13 +159,20 @@ def _trim_decimal(value) -> str:
     return text or "0"
 
 
+def _required_display(item: KitchenPurchaseOrderItem) -> str:
+    amount = item.required_grams or Decimal("0")
+    base = item.base_unit_snapshot or "g"
+    if base == "g":
+        return f"{_trim_decimal(amount / Decimal('1000'))} kg（{_trim_decimal(amount)} g）"
+    return f"{_trim_decimal(amount)} {base}"
+
+
 def _round_up_increment(value: Decimal, increment: Decimal) -> Decimal:
     if value <= 0:
         return Decimal("0")
     if increment <= 0:
         increment = Decimal("1")
-    steps = (value / increment).to_integral_value(rounding=ROUND_CEILING)
-    return steps * increment
+    return (value / increment).to_integral_value(rounding=ROUND_CEILING) * increment
 
 
 def _commit(success: str, redirect_to: str, **values):
@@ -176,10 +186,7 @@ def _commit(success: str, redirect_to: str, **values):
 
 
 def _active_confirmed_orders(service_date: date) -> bool:
-    return (
-        KitchenPurchaseOrder.query.filter_by(service_date=service_date, status="confirmed").first()
-        is not None
-    )
+    return KitchenPurchaseOrder.query.filter_by(service_date=service_date, status="confirmed").first() is not None
 
 
 def _require_draft_plan(plan: KitchenMenuPlan) -> bool:
@@ -187,6 +194,37 @@ def _require_draft_plan(plan: KitchenMenuPlan) -> bool:
         flash("這張菜單已確認，請先重開草稿才能修改。", "warning")
         return False
     return True
+
+
+def _school_meal_conflict(plan: KitchenMenuPlan, school_id: int) -> KitchenMenuAssignment | None:
+    """同校、同日、同餐別只能出現在一張菜單，避免採購重複計算。"""
+    return (
+        KitchenMenuAssignment.query.join(KitchenMenuPlan)
+        .filter(
+            KitchenMenuAssignment.school_id == school_id,
+            KitchenMenuAssignment.plan_id != plan.id,
+            KitchenMenuPlan.service_date == plan.service_date,
+            KitchenMenuPlan.meal_type == plan.meal_type,
+        )
+        .first()
+    )
+
+
+def _plan_has_assignment_conflict(plan: KitchenMenuPlan, service_date: date, meal_type: str) -> bool:
+    school_ids = [x.school_id for x in plan.assignments]
+    if not school_ids:
+        return False
+    return (
+        KitchenMenuAssignment.query.join(KitchenMenuPlan)
+        .filter(
+            KitchenMenuAssignment.school_id.in_(school_ids),
+            KitchenMenuAssignment.plan_id != plan.id,
+            KitchenMenuPlan.service_date == service_date,
+            KitchenMenuPlan.meal_type == meal_type,
+        )
+        .first()
+        is not None
+    )
 
 
 # ─────────────────────────────────────────────
@@ -198,16 +236,12 @@ def _require_draft_plan(plan: KitchenMenuPlan) -> bool:
 def index():
     today = date.today()
     week_end = today + timedelta(days=6)
-    plans = (
-        KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(today, week_end))
-        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
-        .all()
-    )
-    recent_orders = (
-        KitchenPurchaseOrder.query.order_by(KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.id.desc())
-        .limit(10)
-        .all()
-    )
+    plans = KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(today, week_end)).order_by(
+        KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type
+    ).all()
+    recent_orders = KitchenPurchaseOrder.query.order_by(
+        KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.id.desc()
+    ).limit(10).all()
     return render_template(
         "kitchen/dashboard.html",
         plans=plans,
@@ -219,7 +253,7 @@ def index():
 
 
 # ─────────────────────────────────────────────
-# School CRUD
+# School / Supplier CRUD
 # ─────────────────────────────────────────────
 
 
@@ -232,7 +266,6 @@ def schools():
             return redirect(url_for("order_tool.schools"))
         db.session.add(KitchenSchool(name=name, code=request.form.get("code", "").strip() or None))
         return _commit("學校已新增。", "order_tool.schools")
-
     rows = KitchenSchool.query.order_by(KitchenSchool.active.desc(), KitchenSchool.name).all()
     edit_row = db.session.get(KitchenSchool, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
     return render_template("kitchen/schools.html", rows=rows, edit_row=edit_row)
@@ -261,11 +294,6 @@ def school_toggle(school_id: int):
     return _commit("學校狀態已更新。", "order_tool.schools")
 
 
-# ─────────────────────────────────────────────
-# Supplier CRUD
-# ─────────────────────────────────────────────
-
-
 @order_bp.route("/suppliers", methods=["GET", "POST"])
 def suppliers():
     if request.method == "POST":
@@ -279,7 +307,6 @@ def suppliers():
             note=request.form.get("note", "").strip() or None,
         ))
         return _commit("廠商已新增。", "order_tool.suppliers")
-
     rows = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
     edit_row = db.session.get(KitchenSupplier, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
     return render_template("kitchen/suppliers.html", rows=rows, edit_row=edit_row)
@@ -317,30 +344,33 @@ def supplier_toggle(supplier_id: int):
 def _ingredient_form_values():
     name = request.form.get("name", "").strip()
     supplier_id = _int(request.form.get("supplier_id"), default=None)
+    base_unit = request.form.get("base_unit", "g").strip()
     purchase_unit = request.form.get("purchase_unit", "kg").strip()
-    grams_per_unit = _decimal(request.form.get("grams_per_purchase_unit"))
+    units_per_purchase = _decimal(request.form.get("grams_per_purchase_unit"))
     unit_price = _decimal(request.form.get("unit_price"))
     increment = _decimal(request.form.get("order_increment"))
     note = request.form.get("note", "").strip() or None
 
     if not name:
         return None, "食材名稱不可空白。"
+    if base_unit not in BASE_UNITS:
+        return None, "配方基本單位不正確。"
     if purchase_unit not in PURCHASE_UNITS:
         return None, "採購單位不正確。"
-    if grams_per_unit is None or grams_per_unit <= 0:
-        return None, "每採購單位克數必須大於 0。"
+    if units_per_purchase is None or units_per_purchase <= 0:
+        return None, f"每採購單位包含的 {base_unit} 數量必須大於 0。"
     if unit_price is None or unit_price < 0:
         return None, "單價不可為負數。"
     if increment is None or increment <= 0:
         return None, "最小叫貨增量必須大於 0。"
     if supplier_id is not None and not db.session.get(KitchenSupplier, supplier_id):
         return None, "找不到指定廠商。"
-
     return {
         "name": name,
         "supplier_id": supplier_id,
+        "base_unit": base_unit,
         "purchase_unit": purchase_unit,
-        "grams_per_purchase_unit": grams_per_unit,
+        "grams_per_purchase_unit": units_per_purchase,
         "unit_price": unit_price,
         "order_increment": increment,
         "note": note,
@@ -356,7 +386,6 @@ def ingredients():
             return redirect(url_for("order_tool.ingredients"))
         db.session.add(KitchenIngredient(**values))
         return _commit("食材已新增。", "order_tool.ingredients")
-
     rows = KitchenIngredient.query.order_by(KitchenIngredient.active.desc(), KitchenIngredient.name).all()
     suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
     edit_row = db.session.get(KitchenIngredient, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
@@ -366,6 +395,7 @@ def ingredients():
         suppliers=suppliers_all,
         edit_row=edit_row,
         units=PURCHASE_UNITS,
+        base_units=BASE_UNITS,
     )
 
 
@@ -433,7 +463,6 @@ def recipes():
             db.session.rollback()
             flash("菜色名稱已存在。", "error")
             return redirect(url_for("order_tool.recipes"))
-
     rows = KitchenRecipe.query.order_by(KitchenRecipe.active.desc(), KitchenRecipe.category, KitchenRecipe.name).all()
     edit_row = db.session.get(KitchenRecipe, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
     return render_template("kitchen/recipes.html", rows=rows, edit_row=edit_row, categories=CATEGORIES)
@@ -488,12 +517,7 @@ def recipe_copy(recipe_id: int):
     while KitchenRecipe.query.filter_by(name=name).first():
         name = f"{base} {index}"
         index += 1
-    copy = KitchenRecipe(
-        name=name,
-        category=source.category,
-        serving_output_g=source.serving_output_g,
-        note=source.note,
-    )
+    copy = KitchenRecipe(name=name, category=source.category, serving_output_g=source.serving_output_g, note=source.note)
     db.session.add(copy)
     db.session.flush()
     for x in source.ingredients:
@@ -503,7 +527,7 @@ def recipe_copy(recipe_id: int):
             grams_per_person=x.grams_per_person,
         ))
     db.session.commit()
-    flash("已複製菜色，可直接修改不同食材或克數。", "success")
+    flash("已複製菜色，可直接修改食材或每人用量。", "success")
     return redirect(url_for("order_tool.recipe_detail", recipe_id=copy.id))
 
 
@@ -513,18 +537,17 @@ def recipe_ingredient_add(recipe_id: int):
     if not recipe:
         abort(404)
     ingredient_id = _int(request.form.get("ingredient_id"), default=0) or 0
-    grams = _decimal(request.form.get("grams_per_person"))
+    amount = _decimal(request.form.get("grams_per_person"))
     ingredient = db.session.get(KitchenIngredient, ingredient_id)
-    if not ingredient or not ingredient.active or grams is None or grams <= 0:
-        flash("食材或每人克數不正確。", "error")
+    if not ingredient or not ingredient.active or amount is None or amount <= 0:
+        flash("食材或每人用量不正確。", "error")
         return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
-
     existing = KitchenRecipeIngredient.query.filter_by(recipe_id=recipe_id, ingredient_id=ingredient_id).first()
     if existing:
-        existing.grams_per_person = grams
-        message = "配方克數已更新。"
+        existing.grams_per_person = amount
+        message = "配方用量已更新。"
     else:
-        db.session.add(KitchenRecipeIngredient(recipe_id=recipe_id, ingredient_id=ingredient_id, grams_per_person=grams))
+        db.session.add(KitchenRecipeIngredient(recipe_id=recipe_id, ingredient_id=ingredient_id, grams_per_person=amount))
         message = "食材已加入配方。"
     db.session.commit()
     flash(message, "success")
@@ -536,13 +559,13 @@ def recipe_ingredient_update(row_id: int):
     row = db.session.get(KitchenRecipeIngredient, row_id)
     if not row:
         abort(404)
-    grams = _decimal(request.form.get("grams_per_person"))
-    if grams is None or grams <= 0:
-        flash("每人克數必須大於 0。", "error")
+    amount = _decimal(request.form.get("grams_per_person"))
+    if amount is None or amount <= 0:
+        flash("每人用量必須大於 0。", "error")
         return redirect(url_for("order_tool.recipe_detail", recipe_id=row.recipe_id))
-    row.grams_per_person = grams
+    row.grams_per_person = amount
     db.session.commit()
-    flash("每人克數已更新。", "success")
+    flash("每人用量已更新。", "success")
     return redirect(url_for("order_tool.recipe_detail", recipe_id=row.recipe_id))
 
 
@@ -590,19 +613,13 @@ def plans():
 
     start = _date(request.args.get("start"), default=date.today()) or date.today()
     end = start + timedelta(days=13)
-    rows = (
-        KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(start, end))
-        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type, KitchenMenuPlan.name)
-        .all()
-    )
+    rows = KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(start, end)).order_by(
+        KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type, KitchenMenuPlan.name
+    ).all()
     days = []
     for offset in range(7):
         day = start + timedelta(days=offset)
-        days.append({
-            "date": day,
-            "weekday": WEEKDAY_LABELS[day.weekday()],
-            "plans": [p for p in rows if p.service_date == day],
-        })
+        days.append({"date": day, "weekday": WEEKDAY_LABELS[day.weekday()], "plans": [p for p in rows if p.service_date == day]})
     return render_template(
         "kitchen/plans.html",
         rows=rows,
@@ -618,13 +635,11 @@ def plan_detail(plan_id: int):
     plan = db.session.get(KitchenMenuPlan, plan_id)
     if not plan:
         abort(404)
-    recipes_all = KitchenRecipe.query.filter_by(active=True).order_by(KitchenRecipe.category, KitchenRecipe.name).all()
-    schools_all = KitchenSchool.query.filter_by(active=True).order_by(KitchenSchool.name).all()
     return render_template(
         "kitchen/plan_detail.html",
         plan=plan,
-        recipes=recipes_all,
-        schools=schools_all,
+        recipes=KitchenRecipe.query.filter_by(active=True).order_by(KitchenRecipe.category, KitchenRecipe.name).all(),
+        schools=KitchenSchool.query.filter_by(active=True).order_by(KitchenSchool.name).all(),
         total_people=sum(max(x.headcount, 0) for x in plan.assignments),
         has_confirmed_orders=_active_confirmed_orders(plan.service_date),
         meal_types=MEAL_TYPES,
@@ -643,6 +658,9 @@ def plan_update(plan_id: int):
     name = request.form.get("name", "").strip()
     if not service_date or meal_type not in MEAL_TYPES or not name:
         flash("日期、餐別或名稱不正確。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    if _plan_has_assignment_conflict(plan, service_date, meal_type):
+        flash("這張菜單裡有學校已被安排在目標日期的同一餐別，無法變更日期/餐別。", "error")
         return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     plan.service_date = service_date
     plan.meal_type = meal_type
@@ -705,6 +723,13 @@ def assignment_add(plan_id: int):
         row.headcount = headcount
         message = "學校人數已更新。"
     else:
+        conflict = _school_meal_conflict(plan, school_id)
+        if conflict:
+            flash(
+                f"{school.name} 已經在 {plan.service_date} 的 {plan.meal_type} 另一張菜單中，不能重複加入，否則採購會重複計算。",
+                "error",
+            )
+            return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
         db.session.add(KitchenMenuAssignment(plan_id=plan_id, school_id=school_id, headcount=headcount))
         message = "學校已加入菜單。"
     db.session.commit()
@@ -755,7 +780,24 @@ def plan_copy(plan_id: int):
     if KitchenMenuPlan.query.filter_by(service_date=target_date, meal_type=source.meal_type, name=source.name).first():
         flash("目標日期已有相同餐別與名稱的菜單。", "error")
         return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
-
+    conflicts = []
+    for x in source.assignments:
+        probe = KitchenMenuPlan(service_date=target_date, meal_type=source.meal_type)
+        probe.id = -1
+        existing = (
+            KitchenMenuAssignment.query.join(KitchenMenuPlan)
+            .filter(
+                KitchenMenuAssignment.school_id == x.school_id,
+                KitchenMenuPlan.service_date == target_date,
+                KitchenMenuPlan.meal_type == source.meal_type,
+            )
+            .first()
+        )
+        if existing:
+            conflicts.append(x.school.name)
+    if conflicts:
+        flash("以下學校在目標日期同餐別已有菜單，請先處理：" + "、".join(conflicts), "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     copy = KitchenMenuPlan(
         service_date=target_date,
         meal_type=source.meal_type,
@@ -782,6 +824,10 @@ def plan_confirm(plan_id: int):
     if not plan.items or sum(x.headcount for x in plan.assignments) <= 0:
         flash("至少要有菜色與大於 0 的供餐人數才能確認。", "error")
         return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    for x in plan.assignments:
+        if _school_meal_conflict(plan, x.school_id):
+            flash(f"{x.school.name} 在同一天同餐別還出現在另一張菜單，請先修正再確認。", "error")
+            return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     plan.status = "confirmed"
     db.session.commit()
     flash("菜單已確認。", "success")
@@ -824,14 +870,13 @@ def plan_delete(plan_id: int):
 def _supplier_identity(ingredient: KitchenIngredient):
     if ingredient.supplier_id and ingredient.supplier:
         return f"supplier:{ingredient.supplier_id}", ingredient.supplier_id, ingredient.supplier.name
-    return "unassigned", None, "⚠ 未指定供應商"
+    # 未指定供應商要每個食材各自一張草稿，否則不同食材會被硬塞進同一張「未指定」單。
+    return f"unassigned:{ingredient.id}", None, "⚠ 未指定供應商"
 
 
 def _requirements_for_date(service_date: date):
     plans_on_day = KitchenMenuPlan.query.filter_by(service_date=service_date).all()
-    # supplier_key -> ingredient_id -> aggregate row
     grouped: dict[str, dict[int, dict]] = defaultdict(dict)
-
     for plan in plans_on_day:
         people = sum(max(x.headcount, 0) for x in plan.assignments)
         if people <= 0:
@@ -840,29 +885,28 @@ def _requirements_for_date(service_date: date):
             for component in menu_item.recipe.ingredients:
                 ing = component.ingredient
                 supplier_key, supplier_id, supplier_name = _supplier_identity(ing)
-                grams = (component.grams_per_person or Decimal("0")) * people
+                base_amount = (component.grams_per_person or Decimal("0")) * people
                 current = grouped[supplier_key].get(ing.id)
                 if current is None:
                     current = {
                         "supplier_id": supplier_id,
                         "supplier_name": supplier_name,
                         "ingredient": ing,
-                        "required_grams": Decimal("0"),
+                        "required_amount": Decimal("0"),
                     }
                     grouped[supplier_key][ing.id] = current
-                current["required_grams"] += grams
+                current["required_amount"] += base_amount
     return grouped
 
 
 def _generate_date_orders(service_date: date):
-    # 已有任一 confirmed 採購單時，整天都不自動重算，避免產生新供應商單造成重複叫貨。
     if _active_confirmed_orders(service_date):
         return 0, True
 
     requirements = _requirements_for_date(service_date)
     active_keys = set(requirements.keys())
     existing_orders = KitchenPurchaseOrder.query.filter_by(service_date=service_date).all()
-    existing_by_key = {x.supplier_key: x for x in existing_orders}
+    existing_by_key = {x.supplier_key: x for x in existing_orders if x.status != "cancelled"}
     count = 0
 
     for supplier_key, ingredient_rows in requirements.items():
@@ -874,44 +918,71 @@ def _generate_date_orders(service_date: date):
                 supplier_id=first["supplier_id"],
                 supplier_key=supplier_key,
                 supplier_name_snapshot=first["supplier_name"],
+                supplier_overridden=False,
                 status="draft",
             )
             db.session.add(order)
             db.session.flush()
         else:
             order.status = "draft"
-            order.supplier_id = first["supplier_id"]
-            order.supplier_name_snapshot = first["supplier_name"]
-            KitchenPurchaseOrderItem.query.filter_by(order_id=order.id).delete(synchronize_session=False)
-            db.session.flush()
+            # 使用者沒有人工換過供應商時才跟 master data 同步。
+            if not order.supplier_overridden:
+                order.supplier_id = first["supplier_id"]
+                order.supplier_name_snapshot = first["supplier_name"]
+
+        existing_items = {x.ingredient_id: x for x in order.items}
+        seen_ingredient_ids = set()
 
         for data in ingredient_rows.values():
             ing = data["ingredient"]
-            grams_per_unit = ing.grams_per_purchase_unit or Decimal("0")
+            units_per_purchase = ing.grams_per_purchase_unit or Decimal("0")
             increment = ing.order_increment or Decimal("0")
-            if grams_per_unit <= 0 or increment <= 0:
+            if units_per_purchase <= 0 or increment <= 0:
                 continue
-            required_grams = data["required_grams"]
-            required_qty = required_grams / grams_per_unit
+            required_amount = data["required_amount"]
+            required_qty = required_amount / units_per_purchase
             recommended = _round_up_increment(required_qty, increment)
-            unit_price = ing.unit_price or Decimal("0")
-            item = KitchenPurchaseOrderItem(
-                order_id=order.id,
-                ingredient_id=ing.id,
-                ingredient_name_snapshot=ing.name,
-                required_grams=required_grams,
-                required_qty=required_qty,
-                purchase_unit_snapshot=ing.purchase_unit,
-                grams_per_purchase_unit_snapshot=grams_per_unit,
-                recommended_order_qty=recommended,
-                actual_order_qty=recommended,
-                unit_price_snapshot=unit_price,
-                amount=recommended * unit_price,
-            )
-            db.session.add(item)
+            seen_ingredient_ids.add(ing.id)
+
+            item = existing_items.get(ing.id)
+            if item is None:
+                unit_price = ing.unit_price or Decimal("0")
+                item = KitchenPurchaseOrderItem(
+                    order_id=order.id,
+                    ingredient_id=ing.id,
+                    ingredient_name_snapshot=ing.name,
+                    base_unit_snapshot=ing.base_unit or "g",
+                    required_grams=required_amount,
+                    required_qty=required_qty,
+                    purchase_unit_snapshot=ing.purchase_unit,
+                    grams_per_purchase_unit_snapshot=units_per_purchase,
+                    recommended_order_qty=recommended,
+                    actual_order_qty=recommended,
+                    unit_price_snapshot=unit_price,
+                    amount=recommended * unit_price,
+                    manual_override=False,
+                )
+                db.session.add(item)
+            else:
+                # 永遠更新「需求」與「系統建議」，但人工實際量/價格/備註要保留。
+                item.ingredient_name_snapshot = ing.name
+                item.base_unit_snapshot = ing.base_unit or "g"
+                item.required_grams = required_amount
+                item.required_qty = required_qty
+                item.purchase_unit_snapshot = ing.purchase_unit
+                item.grams_per_purchase_unit_snapshot = units_per_purchase
+                item.recommended_order_qty = recommended
+                if not item.manual_override:
+                    item.actual_order_qty = recommended
+                    item.unit_price_snapshot = ing.unit_price or Decimal("0")
+                    item.amount = item.actual_order_qty * item.unit_price_snapshot
+
+        # 原本需求已不存在的 item 才刪除；仍有需求的人工修改保留。
+        for ingredient_id, item in existing_items.items():
+            if ingredient_id not in seen_ingredient_ids:
+                db.session.delete(item)
         count += 1
 
-    # 需求已不存在的舊草稿直接移除；confirmed 在前面已整天阻擋。
     for order in existing_orders:
         if order.status == "draft" and order.supplier_key not in active_keys:
             db.session.delete(order)
@@ -920,21 +991,18 @@ def _generate_date_orders(service_date: date):
     return count, False
 
 
-@order_bp.route("/purchases", methods=["GET"])
+@order_bp.get("/purchases")
 def purchases():
     start = _date(request.args.get("start"), default=date.today() - timedelta(days=7)) or date.today()
     end = _date(request.args.get("end"), default=date.today() + timedelta(days=14)) or start
     if end < start:
         start, end = end, start
-    orders = (
-        KitchenPurchaseOrder.query.filter(KitchenPurchaseOrder.service_date.between(start, end))
-        .order_by(KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.supplier_name_snapshot)
-        .all()
-    )
+    orders = KitchenPurchaseOrder.query.filter(KitchenPurchaseOrder.service_date.between(start, end)).order_by(
+        KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.supplier_name_snapshot
+    ).all()
     return render_template("kitchen/purchases.html", orders=orders, start=start, end=end)
 
 
-# 舊網址相容：/purchase 導向新的持久化採購頁。
 @order_bp.get("/purchase")
 def purchase_legacy_redirect():
     args = {}
@@ -954,7 +1022,6 @@ def generate_purchases():
     if (end - start).days > 31:
         flash("一次最多產生 32 天的採購草稿。", "error")
         return redirect(url_for("order_tool.purchases", start=start, end=end))
-
     created = 0
     blocked_dates = []
     day = start
@@ -964,9 +1031,8 @@ def generate_purchases():
         if blocked:
             blocked_dates.append(str(day))
         day += timedelta(days=1)
-
     if created:
-        flash(f"已建立 / 更新 {created} 張採購草稿。", "success")
+        flash(f"已建立 / 更新 {created} 張採購草稿；人工調整過的實際叫貨量與單價會保留。", "success")
     if blocked_dates:
         flash("以下日期已有已確認採購單，因此沒有自動重算：" + "、".join(blocked_dates), "warning")
     if not created and not blocked_dates:
@@ -979,14 +1045,12 @@ def purchase_detail(order_id: int):
     order = db.session.get(KitchenPurchaseOrder, order_id)
     if not order:
         abort(404)
-    suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
-    do_print = request.args.get("print") == "1"
     return render_template(
         "kitchen/purchase_detail.html",
         order=order,
-        suppliers=suppliers_all,
+        suppliers=KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all(),
         total=_order_total(order),
-        do_print=do_print,
+        do_print=request.args.get("print") == "1",
     )
 
 
@@ -998,34 +1062,22 @@ def purchase_update(order_id: int):
     if order.status != "draft":
         flash("只有草稿採購單可以修改。", "error")
         return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
-
     supplier_id = _int(request.form.get("supplier_id"), default=None)
     if supplier_id is not None:
         supplier = db.session.get(KitchenSupplier, supplier_id)
         if not supplier:
             flash("找不到指定廠商。", "error")
             return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
-        new_key = f"supplier:{supplier.id}"
         new_name = supplier.name
     else:
         supplier = None
-        new_key = "unassigned"
         new_name = "⚠ 未指定供應商"
-
-    conflict = KitchenPurchaseOrder.query.filter(
-        KitchenPurchaseOrder.service_date == order.service_date,
-        KitchenPurchaseOrder.supplier_key == new_key,
-        KitchenPurchaseOrder.id != order.id,
-    ).first()
-    if conflict:
-        flash("同一天已存在這個廠商的採購單，請先處理該單，避免重複叫貨。", "error")
-        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
-
+    # supplier_key 不改：它代表系統原始分組，人工換廠商只是此張草稿 override。
     order.supplier_id = supplier.id if supplier else None
-    order.supplier_key = new_key
     order.supplier_name_snapshot = new_name
+    order.supplier_overridden = True
     order.note = request.form.get("note", "").strip() or None
-    return _commit("採購單資料已更新。", "order_tool.purchase_detail", order_id=order_id)
+    return _commit("採購單廠商/備註已更新；重新計算需求時會保留這個人工廠商。", "order_tool.purchase_detail", order_id=order_id)
 
 
 @order_bp.post("/purchase-items/<int:item_id>/update")
@@ -1045,8 +1097,9 @@ def purchase_item_update(item_id: int):
     item.unit_price_snapshot = price
     item.amount = actual * price
     item.note = request.form.get("note", "").strip() or None
+    item.manual_override = True
     db.session.commit()
-    flash("採購項目已更新。", "success")
+    flash("採購項目已更新；之後重新產生需求也不會洗掉這次人工調整。", "success")
     return redirect(url_for("order_tool.purchase_detail", order_id=item.order_id))
 
 
@@ -1064,9 +1117,7 @@ def purchase_confirm(order_id: int):
     if not order.supplier_id:
         flash("正式確認前必須指定供應商。", "error")
         return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
-
     order.status = "confirmed"
-    # 確認任何正式採購時，同日菜單一起鎖定，防止操作人員誤以為改菜單會改掉已下單內容。
     for plan in KitchenMenuPlan.query.filter_by(service_date=order.service_date).all():
         plan.status = "confirmed"
     db.session.commit()
@@ -1081,7 +1132,7 @@ def purchase_reopen(order_id: int):
         abort(404)
     order.status = "draft"
     db.session.commit()
-    flash("採購單已重開草稿。既有 snapshot 數字仍保留，除非你重新按產生草稿。", "warning")
+    flash("採購單已重開草稿；既有 snapshot 與人工調整仍保留。", "warning")
     return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
 
 

--- a/blueprints/order_tool.py
+++ b/blueprints/order_tool.py
@@ -1,17 +1,28 @@
-"""團膳菜單 / 配方 / 採購叫貨 Blueprint。
+"""團膳菜單 / 配方 / 採購叫貨正式模組。
 
-流程：
-中央菜單 Plan → 指派學校與人數 → Recipe BOM（每人 AP 克數）
-→ 自動彙總食材 → 依供應商分組 → 列印 / 另存 PDF。
+核心流程：
+Recipe BOM（每人 AP 克數）→ 中央菜單 → 學校人數
+→ 食材需求彙總 → 供應商採購草稿 → 人工調整 → Confirm snapshot。
 """
 
 from __future__ import annotations
 
+import secrets
 from collections import defaultdict
-from datetime import date, datetime, timedelta
-from decimal import Decimal
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation, ROUND_CEILING
 
-from flask import Blueprint, abort, redirect, render_template_string, request, url_for
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from sqlalchemy.exc import IntegrityError
 
 from extensions import db
@@ -20,6 +31,8 @@ from models import (
     KitchenMenuAssignment,
     KitchenMenuPlan,
     KitchenMenuPlanItem,
+    KitchenPurchaseOrder,
+    KitchenPurchaseOrderItem,
     KitchenRecipe,
     KitchenRecipeIngredient,
     KitchenSchool,
@@ -29,89 +42,156 @@ from models import (
 
 order_bp = Blueprint("order_tool", __name__)
 
-
-STYLE = r"""
-<style>
-:root{
-  --bg:#f5f7fb;--card:#fff;--text:#17202a;--muted:#667085;--line:#e5e7eb;
-  --brand:#1769aa;--brand2:#0f5b91;--danger:#b42318;--ok:#157347;
-}
-*{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);
-font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans TC","Microsoft JhengHei",sans-serif}
-a{color:var(--brand);text-decoration:none}.wrap{max-width:1180px;margin:auto;padding:24px}
-.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px;flex-wrap:wrap}
-h1{font-size:26px;margin:0}h2{font-size:20px;margin:0 0 14px}h3{font-size:17px;margin:0 0 10px}
-.nav{display:flex;gap:8px;flex-wrap:wrap}.nav a,.btn{display:inline-block;border:0;border-radius:10px;
-padding:9px 14px;background:var(--brand);color:#fff;cursor:pointer;font-size:14px}.nav a:hover,.btn:hover{background:var(--brand2)}
-.btn.secondary{background:#eef3f8;color:#24445f}.btn.danger{background:#fff0ee;color:var(--danger)}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}.span-4{grid-column:span 4}.span-5{grid-column:span 5}
-.span-6{grid-column:span 6}.span-7{grid-column:span 7}.span-8{grid-column:span 8}.span-12{grid-column:span 12}
-.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px;box-shadow:0 2px 8px rgba(16,24,40,.04)}
-.stat{font-size:30px;font-weight:750}.muted{color:var(--muted);font-size:13px}.row{display:flex;gap:10px;align-items:end;flex-wrap:wrap}
-.field{display:flex;flex-direction:column;gap:5px;min-width:150px;flex:1}label{font-size:13px;color:#475467;font-weight:600}
-input,select,textarea{width:100%;padding:9px 10px;border:1px solid #cfd6df;border-radius:9px;background:#fff;font:inherit}
-table{width:100%;border-collapse:collapse}th,td{padding:10px 8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top;font-size:14px}
-th{font-size:12px;color:#667085;background:#fafbfc}.right{text-align:right}.pill{display:inline-block;background:#eef6ff;color:#175c91;border-radius:999px;padding:3px 8px;font-size:12px}
-.empty{padding:28px;text-align:center;color:#667085}.inline{display:inline}.notice{padding:10px 12px;border-radius:10px;background:#fff8e6;color:#7a4b00;margin-bottom:14px}
-@media(max-width:800px){.span-4,.span-5,.span-6,.span-7,.span-8{grid-column:span 12}.wrap{padding:14px}table{display:block;overflow-x:auto;white-space:nowrap}}
-@media print{body{background:#fff}.no-print{display:none!important}.wrap{max-width:none;padding:0}.card{box-shadow:none;border:0;padding:0}table{display:table;white-space:normal}th,td{font-size:11px;padding:5px}.purchase-group{break-inside:avoid;margin-bottom:22px}h1{font-size:20px}h2{font-size:16px}}
-</style>
-"""
+CATEGORIES = ("主食", "主菜", "副菜", "青菜", "湯品", "點心", "其他")
+MEAL_TYPES = ("早餐", "午餐", "晚餐", "點心")
+PURCHASE_UNITS = ("kg", "箱", "包", "斤", "瓶", "個", "袋", "桶")
+WEEKDAY_LABELS = ("週一", "週二", "週三", "週四", "週五", "週六", "週日")
 
 
-NAV = r"""
-<div class="top no-print">
-  <h1>團膳管理</h1>
-  <div class="nav">
-    <a href="{{ url_for('order_tool.index') }}">總覽</a>
-    <a href="{{ url_for('order_tool.plans') }}">菜單</a>
-    <a href="{{ url_for('order_tool.recipes') }}">菜色配方</a>
-    <a href="{{ url_for('order_tool.ingredients') }}">食材</a>
-    <a href="{{ url_for('order_tool.schools') }}">學校</a>
-    <a href="{{ url_for('order_tool.suppliers') }}">廠商</a>
-    <a href="{{ url_for('order_tool.purchase') }}">採購叫貨</a>
-  </div>
-</div>
-"""
+# ─────────────────────────────────────────────
+# Security / shared helpers
+# ─────────────────────────────────────────────
 
 
-def _render(title: str, body: str, **ctx):
-    template = f"""<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1"><title>{title}</title>{STYLE}</head>
-<body><main class="wrap">{NAV}{body}</main></body></html>"""
-    return render_template_string(template, **ctx)
+def _csrf_token() -> str:
+    token = session.get("_kitchen_csrf")
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session["_kitchen_csrf"] = token
+    return token
 
 
-def _to_decimal(raw: str | None, default: str = "0") -> Decimal:
+@order_bp.before_request
+def _protect_kitchen():
+    if not session.get("role"):
+        return redirect(url_for("auth.login", next=request.full_path.rstrip("?")))
+
+    if request.method == "POST" and current_app.config.get("KITCHEN_CSRF_ENABLED", True):
+        expected = session.get("_kitchen_csrf", "")
+        received = request.form.get("_csrf_token", "")
+        if not expected or not received or not secrets.compare_digest(expected, received):
+            abort(400, description="安全驗證已失效，請重新整理頁面再操作。")
+    return None
+
+
+@order_bp.errorhandler(400)
+def _bad_request(error):
+    flash(getattr(error, "description", None) or "輸入資料不正確。", "error")
+    return redirect(request.referrer or url_for("order_tool.index"))
+
+
+@order_bp.context_processor
+def _template_helpers():
+    return {
+        "csrf_token": _csrf_token,
+        "status_label": _status_label,
+        "order_total": _order_total,
+        "recipe_total_g": _recipe_total_g,
+        "component_cost": _component_cost,
+        "trim_decimal": _trim_decimal,
+    }
+
+
+def _status_label(status: str) -> str:
+    return {
+        "draft": "草稿",
+        "confirmed": "已確認",
+        "cancelled": "已取消",
+    }.get(status, status or "-")
+
+
+def _decimal(raw, *, default=None) -> Decimal | None:
+    if raw is None or str(raw).strip() == "":
+        return default
     try:
-        return Decimal((raw or default).strip())
-    except Exception:
-        return Decimal(default)
-
-
-def _to_int(raw: str | None, default: int = 0) -> int:
-    try:
-        return int(raw or default)
-    except Exception:
+        value = Decimal(str(raw).strip())
+        if not value.is_finite():
+            return default
+        return value
+    except (InvalidOperation, ValueError):
         return default
 
 
-def _parse_date(raw: str | None, fallback: date | None = None) -> date:
-    if raw:
-        try:
-            return datetime.strptime(raw, "%Y-%m-%d").date()
-        except ValueError:
-            pass
-    return fallback or date.today()
+def _int(raw, *, default=None) -> int | None:
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
 
 
-def _commit_or_back(endpoint: str, **values):
+def _date(raw, *, default=None) -> date | None:
+    if not raw:
+        return default
+    try:
+        return date.fromisoformat(str(raw))
+    except ValueError:
+        return default
+
+
+def _recipe_total_g(recipe: KitchenRecipe) -> Decimal:
+    return sum((x.grams_per_person or Decimal("0") for x in recipe.ingredients), Decimal("0"))
+
+
+def _component_cost(component: KitchenRecipeIngredient) -> Decimal:
+    ing = component.ingredient
+    grams_per_unit = ing.grams_per_purchase_unit or Decimal("0")
+    if grams_per_unit <= 0:
+        return Decimal("0")
+    return (component.grams_per_person or Decimal("0")) / grams_per_unit * (ing.unit_price or Decimal("0"))
+
+
+def _recipe_cost(recipe: KitchenRecipe) -> Decimal:
+    return sum((_component_cost(x) for x in recipe.ingredients), Decimal("0"))
+
+
+def _order_total(order: KitchenPurchaseOrder) -> Decimal:
+    return sum((x.amount or Decimal("0") for x in order.items), Decimal("0"))
+
+
+def _trim_decimal(value) -> str:
+    d = _decimal(value, default=Decimal("0")) or Decimal("0")
+    text = format(d, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _round_up_increment(value: Decimal, increment: Decimal) -> Decimal:
+    if value <= 0:
+        return Decimal("0")
+    if increment <= 0:
+        increment = Decimal("1")
+    steps = (value / increment).to_integral_value(rounding=ROUND_CEILING)
+    return steps * increment
+
+
+def _commit(success: str, redirect_to: str, **values):
     try:
         db.session.commit()
+        flash(success, "success")
     except IntegrityError:
         db.session.rollback()
-        abort(409, description="資料重複，請確認名稱或同日設定是否已存在。")
-    return redirect(url_for(endpoint, **values))
+        flash("資料重複或違反資料關聯，請檢查名稱與設定。", "error")
+    return redirect(url_for(redirect_to, **values))
+
+
+def _active_confirmed_orders(service_date: date) -> bool:
+    return (
+        KitchenPurchaseOrder.query.filter_by(service_date=service_date, status="confirmed").first()
+        is not None
+    )
+
+
+def _require_draft_plan(plan: KitchenMenuPlan) -> bool:
+    if plan.status != "draft":
+        flash("這張菜單已確認，請先重開草稿才能修改。", "warning")
+        return False
+    return True
+
+
+# ─────────────────────────────────────────────
+# Dashboard
+# ─────────────────────────────────────────────
 
 
 @order_bp.get("/")
@@ -119,34 +199,28 @@ def index():
     today = date.today()
     week_end = today + timedelta(days=6)
     plans = (
-        KitchenMenuPlan.query
-        .filter(KitchenMenuPlan.service_date.between(today, week_end))
+        KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(today, week_end))
         .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
         .all()
     )
-    body = r"""
-<div class="grid">
-  <section class="card span-4"><div class="muted">菜色配方</div><div class="stat">{{ recipe_count }}</div></section>
-  <section class="card span-4"><div class="muted">食材</div><div class="stat">{{ ingredient_count }}</div></section>
-  <section class="card span-4"><div class="muted">供餐學校</div><div class="stat">{{ school_count }}</div></section>
-  <section class="card span-12">
-    <div class="top"><div><h2>未來 7 天菜單</h2><div class="muted">一份中央菜單可以同時指派多間學校與各自人數。</div></div>
-    <a class="btn" href="{{ url_for('order_tool.plans') }}">新增菜單</a></div>
-    {% if plans %}<table><thead><tr><th>日期</th><th>餐別</th><th>名稱</th><th>菜色</th><th>學校 / 人數</th><th></th></tr></thead><tbody>
-    {% for p in plans %}<tr><td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name or '中央菜單' }}</td>
-      <td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td>
-      <td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">編輯</a></td></tr>{% endfor %}
-    </tbody></table>{% else %}<div class="empty">這 7 天還沒有菜單。</div>{% endif %}
-  </section>
-</div>"""
-    return _render(
-        "團膳管理",
-        body,
+    recent_orders = (
+        KitchenPurchaseOrder.query.order_by(KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.id.desc())
+        .limit(10)
+        .all()
+    )
+    return render_template(
+        "kitchen/dashboard.html",
         plans=plans,
-        recipe_count=KitchenRecipe.query.count(),
-        ingredient_count=KitchenIngredient.query.count(),
+        recent_orders=recent_orders,
+        recipe_count=KitchenRecipe.query.filter_by(active=True).count(),
+        ingredient_count=KitchenIngredient.query.filter_by(active=True).count(),
         school_count=KitchenSchool.query.filter_by(active=True).count(),
     )
+
+
+# ─────────────────────────────────────────────
+# School CRUD
+# ─────────────────────────────────────────────
 
 
 @order_bp.route("/schools", methods=["GET", "POST"])
@@ -154,19 +228,42 @@ def schools():
     if request.method == "POST":
         name = request.form.get("name", "").strip()
         if not name:
-            abort(400, description="學校名稱不可空白。")
+            flash("學校名稱不可空白。", "error")
+            return redirect(url_for("order_tool.schools"))
         db.session.add(KitchenSchool(name=name, code=request.form.get("code", "").strip() or None))
-        return _commit_or_back("order_tool.schools")
+        return _commit("學校已新增。", "order_tool.schools")
 
-    rows = KitchenSchool.query.order_by(KitchenSchool.name).all()
-    body = r"""
-<div class="grid"><section class="card span-5"><h2>新增學校 / 客戶</h2>
-<form method="post"><div class="field"><label>名稱</label><input name="name" required placeholder="例如：內小"></div><br>
-<div class="field"><label>代碼（可空白）</label><input name="code" placeholder="例如：A01"></div><br><button class="btn">新增</button></form></section>
-<section class="card span-7"><h2>學校清單</h2>{% if rows %}<table><tr><th>代碼</th><th>名稱</th><th>狀態</th></tr>
-{% for r in rows %}<tr><td>{{ r.code or '-' }}</td><td>{{ r.name }}</td><td>{{ '啟用' if r.active else '停用' }}</td></tr>{% endfor %}</table>
-{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
-    return _render("學校", body, rows=rows)
+    rows = KitchenSchool.query.order_by(KitchenSchool.active.desc(), KitchenSchool.name).all()
+    edit_row = db.session.get(KitchenSchool, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
+    return render_template("kitchen/schools.html", rows=rows, edit_row=edit_row)
+
+
+@order_bp.post("/schools/<int:school_id>/update")
+def school_update(school_id: int):
+    row = db.session.get(KitchenSchool, school_id)
+    if not row:
+        abort(404)
+    name = request.form.get("name", "").strip()
+    if not name:
+        flash("學校名稱不可空白。", "error")
+        return redirect(url_for("order_tool.schools", edit=school_id))
+    row.name = name
+    row.code = request.form.get("code", "").strip() or None
+    return _commit("學校資料已更新。", "order_tool.schools")
+
+
+@order_bp.post("/schools/<int:school_id>/toggle")
+def school_toggle(school_id: int):
+    row = db.session.get(KitchenSchool, school_id)
+    if not row:
+        abort(404)
+    row.active = not row.active
+    return _commit("學校狀態已更新。", "order_tool.schools")
+
+
+# ─────────────────────────────────────────────
+# Supplier CRUD
+# ─────────────────────────────────────────────
 
 
 @order_bp.route("/suppliers", methods=["GET", "POST"])
@@ -174,141 +271,279 @@ def suppliers():
     if request.method == "POST":
         name = request.form.get("name", "").strip()
         if not name:
-            abort(400, description="廠商名稱不可空白。")
+            flash("廠商名稱不可空白。", "error")
+            return redirect(url_for("order_tool.suppliers"))
         db.session.add(KitchenSupplier(
             name=name,
             phone=request.form.get("phone", "").strip() or None,
             note=request.form.get("note", "").strip() or None,
         ))
-        return _commit_or_back("order_tool.suppliers")
+        return _commit("廠商已新增。", "order_tool.suppliers")
 
-    rows = KitchenSupplier.query.order_by(KitchenSupplier.name).all()
-    body = r"""
-<div class="grid"><section class="card span-5"><h2>新增廠商</h2><form method="post">
-<div class="field"><label>廠商名稱</label><input name="name" required></div><br><div class="field"><label>電話</label><input name="phone"></div><br>
-<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">新增</button></form></section>
-<section class="card span-7"><h2>廠商清單</h2>{% if rows %}<table><tr><th>廠商</th><th>電話</th><th>備註</th></tr>
-{% for r in rows %}<tr><td>{{ r.name }}</td><td>{{ r.phone or '-' }}</td><td>{{ r.note or '-' }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
-    return _render("廠商", body, rows=rows)
+    rows = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
+    edit_row = db.session.get(KitchenSupplier, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
+    return render_template("kitchen/suppliers.html", rows=rows, edit_row=edit_row)
+
+
+@order_bp.post("/suppliers/<int:supplier_id>/update")
+def supplier_update(supplier_id: int):
+    row = db.session.get(KitchenSupplier, supplier_id)
+    if not row:
+        abort(404)
+    name = request.form.get("name", "").strip()
+    if not name:
+        flash("廠商名稱不可空白。", "error")
+        return redirect(url_for("order_tool.suppliers", edit=supplier_id))
+    row.name = name
+    row.phone = request.form.get("phone", "").strip() or None
+    row.note = request.form.get("note", "").strip() or None
+    return _commit("廠商資料已更新。", "order_tool.suppliers")
+
+
+@order_bp.post("/suppliers/<int:supplier_id>/toggle")
+def supplier_toggle(supplier_id: int):
+    row = db.session.get(KitchenSupplier, supplier_id)
+    if not row:
+        abort(404)
+    row.active = not row.active
+    return _commit("廠商狀態已更新。", "order_tool.suppliers")
+
+
+# ─────────────────────────────────────────────
+# Ingredient CRUD
+# ─────────────────────────────────────────────
+
+
+def _ingredient_form_values():
+    name = request.form.get("name", "").strip()
+    supplier_id = _int(request.form.get("supplier_id"), default=None)
+    purchase_unit = request.form.get("purchase_unit", "kg").strip()
+    grams_per_unit = _decimal(request.form.get("grams_per_purchase_unit"))
+    unit_price = _decimal(request.form.get("unit_price"))
+    increment = _decimal(request.form.get("order_increment"))
+    note = request.form.get("note", "").strip() or None
+
+    if not name:
+        return None, "食材名稱不可空白。"
+    if purchase_unit not in PURCHASE_UNITS:
+        return None, "採購單位不正確。"
+    if grams_per_unit is None or grams_per_unit <= 0:
+        return None, "每採購單位克數必須大於 0。"
+    if unit_price is None or unit_price < 0:
+        return None, "單價不可為負數。"
+    if increment is None or increment <= 0:
+        return None, "最小叫貨增量必須大於 0。"
+    if supplier_id is not None and not db.session.get(KitchenSupplier, supplier_id):
+        return None, "找不到指定廠商。"
+
+    return {
+        "name": name,
+        "supplier_id": supplier_id,
+        "purchase_unit": purchase_unit,
+        "grams_per_purchase_unit": grams_per_unit,
+        "unit_price": unit_price,
+        "order_increment": increment,
+        "note": note,
+    }, None
 
 
 @order_bp.route("/ingredients", methods=["GET", "POST"])
 def ingredients():
-    suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.name).all()
     if request.method == "POST":
-        name = request.form.get("name", "").strip()
-        if not name:
-            abort(400, description="食材名稱不可空白。")
-        supplier_id = _to_int(request.form.get("supplier_id")) or None
-        db.session.add(KitchenIngredient(
-            name=name,
-            unit_price=_to_decimal(request.form.get("unit_price")),
-            supplier_id=supplier_id,
-            note=request.form.get("note", "").strip() or None,
-        ))
-        return _commit_or_back("order_tool.ingredients")
+        values, error = _ingredient_form_values()
+        if error:
+            flash(error, "error")
+            return redirect(url_for("order_tool.ingredients"))
+        db.session.add(KitchenIngredient(**values))
+        return _commit("食材已新增。", "order_tool.ingredients")
 
-    rows = KitchenIngredient.query.order_by(KitchenIngredient.name).all()
-    body = r"""
-<div class="grid"><section class="card span-5"><h2>新增食材</h2><div class="muted">配方一律以「每人幾克」儲存；單價預設為每公斤。</div><br>
-<form method="post"><div class="field"><label>食材名稱</label><input name="name" required placeholder="骨腿丁"></div><br>
-<div class="field"><label>單價 / kg</label><input name="unit_price" type="number" step="0.0001" value="0"></div><br>
-<div class="field"><label>預設供應商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}">{{ s.name }}</option>{% endfor %}</select></div><br>
-<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">新增</button></form></section>
-<section class="card span-7"><h2>食材清單</h2>{% if rows %}<table><tr><th>食材</th><th class="right">單價/kg</th><th>供應商</th></tr>
-{% for r in rows %}<tr><td>{{ r.name }}</td><td class="right">${{ '%.2f'|format(r.unit_price|float) }}</td><td>{{ r.supplier.name if r.supplier else '⚠ 未指定' }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
-    return _render("食材", body, rows=rows, suppliers=suppliers_all)
+    rows = KitchenIngredient.query.order_by(KitchenIngredient.active.desc(), KitchenIngredient.name).all()
+    suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
+    edit_row = db.session.get(KitchenIngredient, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
+    return render_template(
+        "kitchen/ingredients.html",
+        rows=rows,
+        suppliers=suppliers_all,
+        edit_row=edit_row,
+        units=PURCHASE_UNITS,
+    )
+
+
+@order_bp.post("/ingredients/<int:ingredient_id>/update")
+def ingredient_update(ingredient_id: int):
+    row = db.session.get(KitchenIngredient, ingredient_id)
+    if not row:
+        abort(404)
+    values, error = _ingredient_form_values()
+    if error:
+        flash(error, "error")
+        return redirect(url_for("order_tool.ingredients", edit=ingredient_id))
+    for key, value in values.items():
+        setattr(row, key, value)
+    return _commit("食材資料已更新。", "order_tool.ingredients")
+
+
+@order_bp.post("/ingredients/<int:ingredient_id>/toggle")
+def ingredient_toggle(ingredient_id: int):
+    row = db.session.get(KitchenIngredient, ingredient_id)
+    if not row:
+        abort(404)
+    row.active = not row.active
+    return _commit("食材狀態已更新。", "order_tool.ingredients")
+
+
+# ─────────────────────────────────────────────
+# Recipe CRUD / BOM
+# ─────────────────────────────────────────────
+
+
+def _recipe_form_values():
+    name = request.form.get("name", "").strip()
+    category = request.form.get("category", "主菜").strip()
+    output_raw = request.form.get("serving_output_g", "").strip()
+    serving_output = _decimal(output_raw, default=None) if output_raw else None
+    if not name:
+        return None, "菜色名稱不可空白。"
+    if category not in CATEGORIES:
+        return None, "菜色分類不正確。"
+    if serving_output is not None and serving_output < 0:
+        return None, "打菜量不可為負數。"
+    return {
+        "name": name,
+        "category": category,
+        "serving_output_g": serving_output,
+        "note": request.form.get("note", "").strip() or None,
+    }, None
 
 
 @order_bp.route("/recipes", methods=["GET", "POST"])
 def recipes():
     if request.method == "POST":
-        name = request.form.get("name", "").strip()
-        if not name:
-            abort(400, description="菜色名稱不可空白。")
-        output_raw = request.form.get("serving_output_g", "").strip()
-        recipe = KitchenRecipe(
-            name=name,
-            category=request.form.get("category", "").strip() or None,
-            serving_output_g=_to_decimal(output_raw) if output_raw else None,
-            note=request.form.get("note", "").strip() or None,
-        )
+        values, error = _recipe_form_values()
+        if error:
+            flash(error, "error")
+            return redirect(url_for("order_tool.recipes"))
+        recipe = KitchenRecipe(**values)
         db.session.add(recipe)
         try:
             db.session.commit()
+            flash("菜色已建立，請設定每人配方。", "success")
+            return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe.id))
         except IntegrityError:
             db.session.rollback()
-            abort(409, description="菜色名稱已存在。")
-        return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe.id))
+            flash("菜色名稱已存在。", "error")
+            return redirect(url_for("order_tool.recipes"))
 
-    rows = KitchenRecipe.query.order_by(KitchenRecipe.category, KitchenRecipe.name).all()
-    body = r"""
-<div class="grid"><section class="card span-5"><h2>新增菜色</h2><form method="post">
-<div class="field"><label>菜色名稱</label><input name="name" required placeholder="南洋綠咖哩雞"></div><br>
-<div class="field"><label>分類</label><select name="category"><option>主食</option><option selected>主菜</option><option>副菜</option><option>青菜</option><option>湯品</option><option>點心</option></select></div><br>
-<div class="field"><label>預計打菜量 g / 人（可空白）</label><input name="serving_output_g" type="number" step="0.01" placeholder="95"></div><br>
-<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">建立後設定配方</button></form></section>
-<section class="card span-7"><h2>菜色配方</h2>{% if rows %}<table><tr><th>類別</th><th>菜色</th><th class="right">生料 g/人</th><th class="right">打菜 g/人</th><th></th></tr>
-{% for r in rows %}<tr><td><span class="pill">{{ r.category or '未分類' }}</span></td><td>{{ r.name }}</td><td class="right">{{ '%.1f'|format(r.ingredients|sum(attribute='grams_per_person')|float) }}</td>
-<td class="right">{{ '%.1f'|format(r.serving_output_g|float) if r.serving_output_g is not none else '-' }}</td><td><a href="{{ url_for('order_tool.recipe_detail', recipe_id=r.id) }}">編輯配方</a></td></tr>{% endfor %}</table>
-{% else %}<div class="empty">先建立第一道菜。</div>{% endif %}</section></div>"""
-    return _render("菜色配方", body, rows=rows)
+    rows = KitchenRecipe.query.order_by(KitchenRecipe.active.desc(), KitchenRecipe.category, KitchenRecipe.name).all()
+    edit_row = db.session.get(KitchenRecipe, _int(request.args.get("edit"), default=0)) if request.args.get("edit") else None
+    return render_template("kitchen/recipes.html", rows=rows, edit_row=edit_row, categories=CATEGORIES)
 
 
-@order_bp.route("/recipes/<int:recipe_id>", methods=["GET"])
+@order_bp.post("/recipes/<int:recipe_id>/update")
+def recipe_update(recipe_id: int):
+    row = db.session.get(KitchenRecipe, recipe_id)
+    if not row:
+        abort(404)
+    values, error = _recipe_form_values()
+    if error:
+        flash(error, "error")
+        return redirect(url_for("order_tool.recipes", edit=recipe_id))
+    for key, value in values.items():
+        setattr(row, key, value)
+    return _commit("菜色資料已更新。", "order_tool.recipes")
+
+
+@order_bp.post("/recipes/<int:recipe_id>/toggle")
+def recipe_toggle(recipe_id: int):
+    row = db.session.get(KitchenRecipe, recipe_id)
+    if not row:
+        abort(404)
+    row.active = not row.active
+    return _commit("菜色狀態已更新。", "order_tool.recipes")
+
+
+@order_bp.get("/recipes/<int:recipe_id>")
 def recipe_detail(recipe_id: int):
     recipe = db.session.get(KitchenRecipe, recipe_id)
     if not recipe:
         abort(404)
-    ingredients_all = KitchenIngredient.query.order_by(KitchenIngredient.name).all()
-    total_g = sum((x.grams_per_person or 0) for x in recipe.ingredients)
-    total_cost = sum(
-        ((x.grams_per_person or 0) / Decimal("1000")) * (x.ingredient.unit_price or 0)
-        for x in recipe.ingredients
-    )
-    body = r"""
-<div class="top"><div><h1>{{ recipe.name }}</h1><div class="muted">每人配方（AP 採購量）</div></div><a class="btn secondary" href="{{ url_for('order_tool.recipes') }}">← 回菜色清單</a></div>
-<div class="grid"><section class="card span-7"><h2>目前配方</h2>
-{% if recipe.ingredients %}<table><tr><th>食材</th><th class="right">每人 AP</th><th class="right">單價/kg</th><th class="right">每人成本</th><th></th></tr>
-{% for x in recipe.ingredients %}<tr><td>{{ x.ingredient.name }}</td><td class="right">{{ '%.3f'|format(x.grams_per_person|float) }} g</td>
-<td class="right">${{ '%.2f'|format(x.ingredient.unit_price|float) }}</td><td class="right">${{ '%.3f'|format((x.grams_per_person|float/1000)*(x.ingredient.unit_price|float)) }}</td>
-<td><form class="inline" method="post" action="{{ url_for('order_tool.recipe_ingredient_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}</table>
-<div class="row" style="margin-top:14px"><div><b>每份生料：{{ '%.1f'|format(total_g|float) }} g</b></div><div><b>每份成本：約 ${{ '%.2f'|format(total_cost|float) }}</b></div>
-{% if recipe.serving_output_g is not none %}<div><b>打菜量：{{ recipe.serving_output_g }} g</b></div>{% endif %}</div>
-{% else %}<div class="empty">還沒有食材。</div>{% endif %}</section>
-<section class="card span-5"><h2>加入食材</h2>{% if ingredients %}<form method="post" action="{{ url_for('order_tool.recipe_ingredient_add', recipe_id=recipe.id) }}">
-<div class="field"><label>食材</label><select name="ingredient_id" required>{% for i in ingredients %}<option value="{{ i.id }}">{{ i.name }}</option>{% endfor %}</select></div><br>
-<div class="field"><label>每人採購量（g）</label><input name="grams_per_person" type="number" min="0.001" step="0.001" required placeholder="例如 88"></div><br><button class="btn">加入配方</button></form>
-{% else %}<div class="notice">請先到「食材」建立食材。</div><a class="btn" href="{{ url_for('order_tool.ingredients') }}">去建立食材</a>{% endif %}</section></div>"""
-    return _render(
-        recipe.name,
-        body,
+    ingredients_all = KitchenIngredient.query.filter_by(active=True).order_by(KitchenIngredient.name).all()
+    return render_template(
+        "kitchen/recipe_detail.html",
         recipe=recipe,
         ingredients=ingredients_all,
-        total_g=total_g,
-        total_cost=total_cost,
+        total_g=_recipe_total_g(recipe),
+        total_cost=_recipe_cost(recipe),
     )
+
+
+@order_bp.post("/recipes/<int:recipe_id>/copy")
+def recipe_copy(recipe_id: int):
+    source = db.session.get(KitchenRecipe, recipe_id)
+    if not source:
+        abort(404)
+    base = f"{source.name} 複製"
+    name = base
+    index = 2
+    while KitchenRecipe.query.filter_by(name=name).first():
+        name = f"{base} {index}"
+        index += 1
+    copy = KitchenRecipe(
+        name=name,
+        category=source.category,
+        serving_output_g=source.serving_output_g,
+        note=source.note,
+    )
+    db.session.add(copy)
+    db.session.flush()
+    for x in source.ingredients:
+        db.session.add(KitchenRecipeIngredient(
+            recipe_id=copy.id,
+            ingredient_id=x.ingredient_id,
+            grams_per_person=x.grams_per_person,
+        ))
+    db.session.commit()
+    flash("已複製菜色，可直接修改不同食材或克數。", "success")
+    return redirect(url_for("order_tool.recipe_detail", recipe_id=copy.id))
 
 
 @order_bp.post("/recipes/<int:recipe_id>/ingredients")
 def recipe_ingredient_add(recipe_id: int):
-    if not db.session.get(KitchenRecipe, recipe_id):
+    recipe = db.session.get(KitchenRecipe, recipe_id)
+    if not recipe:
         abort(404)
-    ingredient_id = _to_int(request.form.get("ingredient_id"))
-    grams = _to_decimal(request.form.get("grams_per_person"))
-    if ingredient_id <= 0 or grams <= 0:
-        abort(400, description="食材與克數不正確。")
+    ingredient_id = _int(request.form.get("ingredient_id"), default=0) or 0
+    grams = _decimal(request.form.get("grams_per_person"))
+    ingredient = db.session.get(KitchenIngredient, ingredient_id)
+    if not ingredient or not ingredient.active or grams is None or grams <= 0:
+        flash("食材或每人克數不正確。", "error")
+        return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
+
     existing = KitchenRecipeIngredient.query.filter_by(recipe_id=recipe_id, ingredient_id=ingredient_id).first()
     if existing:
         existing.grams_per_person = grams
+        message = "配方克數已更新。"
     else:
-        db.session.add(KitchenRecipeIngredient(
-            recipe_id=recipe_id,
-            ingredient_id=ingredient_id,
-            grams_per_person=grams,
-        ))
+        db.session.add(KitchenRecipeIngredient(recipe_id=recipe_id, ingredient_id=ingredient_id, grams_per_person=grams))
+        message = "食材已加入配方。"
     db.session.commit()
+    flash(message, "success")
     return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
+
+
+@order_bp.post("/recipe-ingredients/<int:row_id>/update")
+def recipe_ingredient_update(row_id: int):
+    row = db.session.get(KitchenRecipeIngredient, row_id)
+    if not row:
+        abort(404)
+    grams = _decimal(request.form.get("grams_per_person"))
+    if grams is None or grams <= 0:
+        flash("每人克數必須大於 0。", "error")
+        return redirect(url_for("order_tool.recipe_detail", recipe_id=row.recipe_id))
+    row.grams_per_person = grams
+    db.session.commit()
+    flash("每人克數已更新。", "success")
+    return redirect(url_for("order_tool.recipe_detail", recipe_id=row.recipe_id))
 
 
 @order_bp.post("/recipe-ingredients/<int:row_id>/delete")
@@ -319,46 +554,63 @@ def recipe_ingredient_delete(row_id: int):
     recipe_id = row.recipe_id
     db.session.delete(row)
     db.session.commit()
+    flash("食材已從配方移除。", "success")
     return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
+
+
+# ─────────────────────────────────────────────
+# Menu plan CRUD
+# ─────────────────────────────────────────────
 
 
 @order_bp.route("/plans", methods=["GET", "POST"])
 def plans():
     if request.method == "POST":
-        service_date = _parse_date(request.form.get("service_date"))
+        service_date = _date(request.form.get("service_date"))
+        meal_type = request.form.get("meal_type", "午餐").strip()
+        name = request.form.get("name", "").strip()
+        if not service_date or meal_type not in MEAL_TYPES or not name:
+            flash("日期、餐別或菜單名稱不正確。", "error")
+            return redirect(url_for("order_tool.plans"))
         plan = KitchenMenuPlan(
             service_date=service_date,
-            meal_type=request.form.get("meal_type", "午餐").strip() or "午餐",
-            name=request.form.get("name", "").strip() or "中央菜單",
+            meal_type=meal_type,
+            name=name,
             note=request.form.get("note", "").strip() or None,
         )
         db.session.add(plan)
         try:
             db.session.commit()
+            flash("菜單已建立。", "success")
+            return redirect(url_for("order_tool.plan_detail", plan_id=plan.id))
         except IntegrityError:
             db.session.rollback()
-            abort(409, description="同一天、同餐別、同名稱的菜單已存在。")
-        return redirect(url_for("order_tool.plan_detail", plan_id=plan.id))
+            flash("同日、同餐別、同名稱的菜單已存在。", "error")
+            return redirect(url_for("order_tool.plans"))
 
-    start = _parse_date(request.args.get("start"), date.today())
+    start = _date(request.args.get("start"), default=date.today()) or date.today()
     end = start + timedelta(days=13)
     rows = (
-        KitchenMenuPlan.query
-        .filter(KitchenMenuPlan.service_date.between(start, end))
-        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
+        KitchenMenuPlan.query.filter(KitchenMenuPlan.service_date.between(start, end))
+        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type, KitchenMenuPlan.name)
         .all()
     )
-    body = r"""
-<div class="grid"><section class="card span-5"><h2>建立中央菜單</h2><form method="post">
-<div class="field"><label>供餐日期</label><input name="service_date" type="date" value="{{ today }}" required></div><br>
-<div class="field"><label>餐別</label><select name="meal_type"><option selected>午餐</option><option>早餐</option><option>晚餐</option><option>點心</option></select></div><br>
-<div class="field"><label>菜單名稱</label><input name="name" value="中央菜單" placeholder="例如 A 菜單"></div><br>
-<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">建立並排菜</button></form></section>
-<section class="card span-7"><div class="top"><h2>{{ start }} 起 14 天</h2><form method="get" class="row"><input name="start" type="date" value="{{ start }}"><button class="btn secondary">查看</button></form></div>
-{% if rows %}<table><tr><th>日期</th><th>餐別</th><th>菜單</th><th>菜色</th><th>供餐</th><th></th></tr>
-{% for p in rows %}<tr><td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name }}</td><td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td>
-<td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">編輯</a></td></tr>{% endfor %}</table>{% else %}<div class="empty">這段期間沒有菜單。</div>{% endif %}</section></div>"""
-    return _render("菜單", body, rows=rows, start=start, today=date.today().isoformat())
+    days = []
+    for offset in range(7):
+        day = start + timedelta(days=offset)
+        days.append({
+            "date": day,
+            "weekday": WEEKDAY_LABELS[day.weekday()],
+            "plans": [p for p in rows if p.service_date == day],
+        })
+    return render_template(
+        "kitchen/plans.html",
+        rows=rows,
+        days=days,
+        start=start,
+        today=date.today().isoformat(),
+        meal_types=MEAL_TYPES,
+    )
 
 
 @order_bp.get("/plans/<int:plan_id>")
@@ -366,47 +618,58 @@ def plan_detail(plan_id: int):
     plan = db.session.get(KitchenMenuPlan, plan_id)
     if not plan:
         abort(404)
-    recipes_all = KitchenRecipe.query.order_by(KitchenRecipe.category, KitchenRecipe.name).all()
+    recipes_all = KitchenRecipe.query.filter_by(active=True).order_by(KitchenRecipe.category, KitchenRecipe.name).all()
     schools_all = KitchenSchool.query.filter_by(active=True).order_by(KitchenSchool.name).all()
-    total_people = sum(x.headcount for x in plan.assignments)
-    body = r"""
-<div class="top"><div><h1>{{ plan.service_date }}・{{ plan.meal_type }}・{{ plan.name }}</h1><div class="muted">先排菜，再指派學校與該日人數。</div></div>
-<a class="btn secondary" href="{{ url_for('order_tool.plans') }}">← 回菜單</a></div>
-<div class="grid"><section class="card span-6"><h2>① 今日菜色</h2>{% if plan.items %}<table><tr><th>類別</th><th>菜色</th><th>生料 g/人</th><th></th></tr>
-{% for x in plan.items %}<tr><td>{{ x.recipe.category or '-' }}</td><td>{{ x.recipe.name }}</td><td>{{ '%.1f'|format(x.recipe.ingredients|sum(attribute='grams_per_person')|float) }}</td>
-<td><form class="inline" method="post" action="{{ url_for('order_tool.plan_item_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}</table>{% else %}<div class="empty">尚未排菜。</div>{% endif %}
-<hr style="border:0;border-top:1px solid #eee;margin:18px 0"><h3>加入菜色</h3>{% if recipes %}<form method="post" action="{{ url_for('order_tool.plan_item_add', plan_id=plan.id) }}" class="row">
-<div class="field"><select name="recipe_id">{% for r in recipes %}<option value="{{ r.id }}">{{ r.category or '未分類' }}｜{{ r.name }}</option>{% endfor %}</select></div><button class="btn">加入</button></form>{% else %}<div class="notice">請先建立菜色配方。</div>{% endif %}</section>
-<section class="card span-6"><h2>② 分配學校 / 人數</h2>{% if plan.assignments %}<table><tr><th>學校</th><th class="right">人數</th><th></th></tr>
-{% for x in plan.assignments %}<tr><td>{{ x.school.name }}</td><td class="right">{{ x.headcount }}</td><td><form class="inline" method="post" action="{{ url_for('order_tool.assignment_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}
-<tr><td><b>總人數</b></td><td class="right"><b>{{ total_people }}</b></td><td></td></tr></table>{% else %}<div class="empty">尚未分配學校。</div>{% endif %}
-<hr style="border:0;border-top:1px solid #eee;margin:18px 0"><h3>加入 / 更新學校</h3>{% if schools %}<form method="post" action="{{ url_for('order_tool.assignment_add', plan_id=plan.id) }}" class="row">
-<div class="field"><label>學校</label><select name="school_id">{% for s in schools %}<option value="{{ s.id }}">{{ s.name }}</option>{% endfor %}</select></div>
-<div class="field"><label>當日人數</label><input name="headcount" type="number" min="0" required></div><button class="btn">儲存</button></form>{% else %}<div class="notice">請先建立學校。</div>{% endif %}</section>
-<section class="card span-12"><div class="top"><div><h2>③ 試算採購</h2><div class="muted">完成菜色與學校後，可直接查看這一天要叫多少貨。</div></div>
-<a class="btn" href="{{ url_for('order_tool.purchase', start=plan.service_date, end=plan.service_date) }}">產生叫貨表</a></div></section></div>"""
-    return _render(
-        "編輯菜單",
-        body,
+    return render_template(
+        "kitchen/plan_detail.html",
         plan=plan,
         recipes=recipes_all,
         schools=schools_all,
-        total_people=total_people,
+        total_people=sum(max(x.headcount, 0) for x in plan.assignments),
+        has_confirmed_orders=_active_confirmed_orders(plan.service_date),
+        meal_types=MEAL_TYPES,
     )
+
+
+@order_bp.post("/plans/<int:plan_id>/update")
+def plan_update(plan_id: int):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
+        abort(404)
+    if not _require_draft_plan(plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    service_date = _date(request.form.get("service_date"))
+    meal_type = request.form.get("meal_type", "").strip()
+    name = request.form.get("name", "").strip()
+    if not service_date or meal_type not in MEAL_TYPES or not name:
+        flash("日期、餐別或名稱不正確。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    plan.service_date = service_date
+    plan.meal_type = meal_type
+    plan.name = name
+    plan.note = request.form.get("note", "").strip() or None
+    return _commit("菜單基本資料已更新。", "order_tool.plan_detail", plan_id=plan_id)
 
 
 @order_bp.post("/plans/<int:plan_id>/items")
 def plan_item_add(plan_id: int):
-    if not db.session.get(KitchenMenuPlan, plan_id):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
         abort(404)
-    recipe_id = _to_int(request.form.get("recipe_id"))
-    if not db.session.get(KitchenRecipe, recipe_id):
-        abort(400)
-    existing = KitchenMenuPlanItem.query.filter_by(plan_id=plan_id, recipe_id=recipe_id).first()
-    if not existing:
-        max_order = max((x.sort_order for x in KitchenMenuPlanItem.query.filter_by(plan_id=plan_id).all()), default=-1)
+    if not _require_draft_plan(plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    recipe_id = _int(request.form.get("recipe_id"), default=0) or 0
+    recipe = db.session.get(KitchenRecipe, recipe_id)
+    if not recipe or not recipe.active:
+        flash("找不到可用菜色。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    if not KitchenMenuPlanItem.query.filter_by(plan_id=plan_id, recipe_id=recipe_id).first():
+        max_order = max((x.sort_order for x in plan.items), default=-1)
         db.session.add(KitchenMenuPlanItem(plan_id=plan_id, recipe_id=recipe_id, sort_order=max_order + 1))
         db.session.commit()
+        flash("菜色已加入。", "success")
+    else:
+        flash("這道菜已在菜單中。", "warning")
     return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
 
 
@@ -416,26 +679,54 @@ def plan_item_delete(row_id: int):
     if not row:
         abort(404)
     plan_id = row.plan_id
+    if not _require_draft_plan(row.plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     db.session.delete(row)
     db.session.commit()
+    flash("菜色已移除。", "success")
     return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
 
 
 @order_bp.post("/plans/<int:plan_id>/assignments")
 def assignment_add(plan_id: int):
-    if not db.session.get(KitchenMenuPlan, plan_id):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
         abort(404)
-    school_id = _to_int(request.form.get("school_id"))
-    headcount = max(_to_int(request.form.get("headcount")), 0)
-    if not db.session.get(KitchenSchool, school_id):
-        abort(400)
+    if not _require_draft_plan(plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    school_id = _int(request.form.get("school_id"), default=0) or 0
+    headcount = _int(request.form.get("headcount"), default=None)
+    school = db.session.get(KitchenSchool, school_id)
+    if not school or not school.active or headcount is None or headcount < 0:
+        flash("學校或人數不正確。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     row = KitchenMenuAssignment.query.filter_by(plan_id=plan_id, school_id=school_id).first()
     if row:
         row.headcount = headcount
+        message = "學校人數已更新。"
     else:
         db.session.add(KitchenMenuAssignment(plan_id=plan_id, school_id=school_id, headcount=headcount))
+        message = "學校已加入菜單。"
     db.session.commit()
+    flash(message, "success")
     return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/assignments/<int:row_id>/update")
+def assignment_update(row_id: int):
+    row = db.session.get(KitchenMenuAssignment, row_id)
+    if not row:
+        abort(404)
+    if not _require_draft_plan(row.plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=row.plan_id))
+    headcount = _int(request.form.get("headcount"), default=None)
+    if headcount is None or headcount < 0:
+        flash("人數不可為負數。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=row.plan_id))
+    row.headcount = headcount
+    db.session.commit()
+    flash("人數已更新。", "success")
+    return redirect(url_for("order_tool.plan_detail", plan_id=row.plan_id))
 
 
 @order_bp.post("/assignments/<int:row_id>/delete")
@@ -444,104 +735,362 @@ def assignment_delete(row_id: int):
     if not row:
         abort(404)
     plan_id = row.plan_id
+    if not _require_draft_plan(row.plan):
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
     db.session.delete(row)
     db.session.commit()
+    flash("學校已從菜單移除。", "success")
     return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
 
 
-def _build_purchase(start: date, end: date):
-    plans = (
-        KitchenMenuPlan.query
-        .filter(KitchenMenuPlan.service_date.between(start, end))
-        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
-        .all()
+@order_bp.post("/plans/<int:plan_id>/copy")
+def plan_copy(plan_id: int):
+    source = db.session.get(KitchenMenuPlan, plan_id)
+    if not source:
+        abort(404)
+    target_date = _date(request.form.get("target_date"))
+    if not target_date:
+        flash("請選擇正確的複製日期。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    if KitchenMenuPlan.query.filter_by(service_date=target_date, meal_type=source.meal_type, name=source.name).first():
+        flash("目標日期已有相同餐別與名稱的菜單。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+    copy = KitchenMenuPlan(
+        service_date=target_date,
+        meal_type=source.meal_type,
+        name=source.name,
+        note=source.note,
+        status="draft",
     )
+    db.session.add(copy)
+    db.session.flush()
+    for x in source.items:
+        db.session.add(KitchenMenuPlanItem(plan_id=copy.id, recipe_id=x.recipe_id, sort_order=x.sort_order))
+    for x in source.assignments:
+        db.session.add(KitchenMenuAssignment(plan_id=copy.id, school_id=x.school_id, headcount=x.headcount))
+    db.session.commit()
+    flash("菜單已複製，請確認新日期的人數。", "success")
+    return redirect(url_for("order_tool.plan_detail", plan_id=copy.id))
 
-    # key = (date, supplier_name, ingredient_id)
-    agg: dict[tuple, dict] = {}
-    plan_summaries = []
 
-    for plan in plans:
-        people = sum(max(a.headcount, 0) for a in plan.assignments)
-        plan_summaries.append({
-            "date": plan.service_date,
-            "meal_type": plan.meal_type,
-            "name": plan.name,
-            "people": people,
-            "schools": len(plan.assignments),
-        })
+@order_bp.post("/plans/<int:plan_id>/confirm")
+def plan_confirm(plan_id: int):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
+        abort(404)
+    if not plan.items or sum(x.headcount for x in plan.assignments) <= 0:
+        flash("至少要有菜色與大於 0 的供餐人數才能確認。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    plan.status = "confirmed"
+    db.session.commit()
+    flash("菜單已確認。", "success")
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/plans/<int:plan_id>/reopen")
+def plan_reopen(plan_id: int):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
+        abort(404)
+    if _active_confirmed_orders(plan.service_date):
+        flash("這一天已有已確認採購單，請先到採購頁重開相關採購單。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    plan.status = "draft"
+    db.session.commit()
+    flash("菜單已重開為草稿。", "success")
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/plans/<int:plan_id>/delete")
+def plan_delete(plan_id: int):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
+        abort(404)
+    if plan.status != "draft" or _active_confirmed_orders(plan.service_date):
+        flash("只能刪除沒有正式採購紀錄的草稿菜單。", "error")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+    db.session.delete(plan)
+    db.session.commit()
+    flash("草稿菜單已刪除。", "success")
+    return redirect(url_for("order_tool.plans"))
+
+
+# ─────────────────────────────────────────────
+# Purchase calculation / persisted orders
+# ─────────────────────────────────────────────
+
+
+def _supplier_identity(ingredient: KitchenIngredient):
+    if ingredient.supplier_id and ingredient.supplier:
+        return f"supplier:{ingredient.supplier_id}", ingredient.supplier_id, ingredient.supplier.name
+    return "unassigned", None, "⚠ 未指定供應商"
+
+
+def _requirements_for_date(service_date: date):
+    plans_on_day = KitchenMenuPlan.query.filter_by(service_date=service_date).all()
+    # supplier_key -> ingredient_id -> aggregate row
+    grouped: dict[str, dict[int, dict]] = defaultdict(dict)
+
+    for plan in plans_on_day:
+        people = sum(max(x.headcount, 0) for x in plan.assignments)
         if people <= 0:
             continue
-
         for menu_item in plan.items:
             for component in menu_item.recipe.ingredients:
                 ing = component.ingredient
-                supplier_name = ing.supplier.name if ing.supplier else "⚠ 未指定供應商"
-                key = (plan.service_date, supplier_name, ing.id)
+                supplier_key, supplier_id, supplier_name = _supplier_identity(ing)
                 grams = (component.grams_per_person or Decimal("0")) * people
-                if key not in agg:
-                    agg[key] = {
-                        "date": plan.service_date,
-                        "supplier": supplier_name,
-                        "ingredient": ing.name,
-                        "grams": Decimal("0"),
-                        "unit_price": ing.unit_price or Decimal("0"),
+                current = grouped[supplier_key].get(ing.id)
+                if current is None:
+                    current = {
+                        "supplier_id": supplier_id,
+                        "supplier_name": supplier_name,
+                        "ingredient": ing,
+                        "required_grams": Decimal("0"),
                     }
-                agg[key]["grams"] += grams
-
-    grouped: dict[tuple, list] = defaultdict(list)
-    for row in agg.values():
-        row["kg"] = row["grams"] / Decimal("1000")
-        row["cost"] = row["kg"] * row["unit_price"]
-        grouped[(row["date"], row["supplier"])].append(row)
-
-    groups = []
-    for (service_date, supplier), rows in sorted(grouped.items(), key=lambda x: (x[0][0], x[0][1])):
-        rows.sort(key=lambda r: r["ingredient"])
-        groups.append({
-            "date": service_date,
-            "supplier": supplier,
-            "rows": rows,
-            "cost": sum((r["cost"] for r in rows), Decimal("0")),
-        })
-
-    total_cost = sum((g["cost"] for g in groups), Decimal("0"))
-    missing_supplier = sum(1 for g in groups if g["supplier"].startswith("⚠"))
-    return groups, plan_summaries, total_cost, missing_supplier
+                    grouped[supplier_key][ing.id] = current
+                current["required_grams"] += grams
+    return grouped
 
 
-@order_bp.get("/purchase")
-def purchase():
-    start = _parse_date(request.args.get("start"), date.today())
-    end = _parse_date(request.args.get("end"), start)
+def _generate_date_orders(service_date: date):
+    # 已有任一 confirmed 採購單時，整天都不自動重算，避免產生新供應商單造成重複叫貨。
+    if _active_confirmed_orders(service_date):
+        return 0, True
+
+    requirements = _requirements_for_date(service_date)
+    active_keys = set(requirements.keys())
+    existing_orders = KitchenPurchaseOrder.query.filter_by(service_date=service_date).all()
+    existing_by_key = {x.supplier_key: x for x in existing_orders}
+    count = 0
+
+    for supplier_key, ingredient_rows in requirements.items():
+        first = next(iter(ingredient_rows.values()))
+        order = existing_by_key.get(supplier_key)
+        if order is None:
+            order = KitchenPurchaseOrder(
+                service_date=service_date,
+                supplier_id=first["supplier_id"],
+                supplier_key=supplier_key,
+                supplier_name_snapshot=first["supplier_name"],
+                status="draft",
+            )
+            db.session.add(order)
+            db.session.flush()
+        else:
+            order.status = "draft"
+            order.supplier_id = first["supplier_id"]
+            order.supplier_name_snapshot = first["supplier_name"]
+            KitchenPurchaseOrderItem.query.filter_by(order_id=order.id).delete(synchronize_session=False)
+            db.session.flush()
+
+        for data in ingredient_rows.values():
+            ing = data["ingredient"]
+            grams_per_unit = ing.grams_per_purchase_unit or Decimal("0")
+            increment = ing.order_increment or Decimal("0")
+            if grams_per_unit <= 0 or increment <= 0:
+                continue
+            required_grams = data["required_grams"]
+            required_qty = required_grams / grams_per_unit
+            recommended = _round_up_increment(required_qty, increment)
+            unit_price = ing.unit_price or Decimal("0")
+            item = KitchenPurchaseOrderItem(
+                order_id=order.id,
+                ingredient_id=ing.id,
+                ingredient_name_snapshot=ing.name,
+                required_grams=required_grams,
+                required_qty=required_qty,
+                purchase_unit_snapshot=ing.purchase_unit,
+                grams_per_purchase_unit_snapshot=grams_per_unit,
+                recommended_order_qty=recommended,
+                actual_order_qty=recommended,
+                unit_price_snapshot=unit_price,
+                amount=recommended * unit_price,
+            )
+            db.session.add(item)
+        count += 1
+
+    # 需求已不存在的舊草稿直接移除；confirmed 在前面已整天阻擋。
+    for order in existing_orders:
+        if order.status == "draft" and order.supplier_key not in active_keys:
+            db.session.delete(order)
+
+    db.session.commit()
+    return count, False
+
+
+@order_bp.route("/purchases", methods=["GET"])
+def purchases():
+    start = _date(request.args.get("start"), default=date.today() - timedelta(days=7)) or date.today()
+    end = _date(request.args.get("end"), default=date.today() + timedelta(days=14)) or start
     if end < start:
         start, end = end, start
+    orders = (
+        KitchenPurchaseOrder.query.filter(KitchenPurchaseOrder.service_date.between(start, end))
+        .order_by(KitchenPurchaseOrder.service_date.desc(), KitchenPurchaseOrder.supplier_name_snapshot)
+        .all()
+    )
+    return render_template("kitchen/purchases.html", orders=orders, start=start, end=end)
 
-    groups, summaries, total_cost, missing_supplier = _build_purchase(start, end)
+
+# 舊網址相容：/purchase 導向新的持久化採購頁。
+@order_bp.get("/purchase")
+def purchase_legacy_redirect():
+    args = {}
+    if request.args.get("start"):
+        args["start"] = request.args["start"]
+    if request.args.get("end"):
+        args["end"] = request.args["end"]
+    return redirect(url_for("order_tool.purchases", **args))
+
+
+@order_bp.post("/purchases/generate")
+def generate_purchases():
+    start = _date(request.form.get("start"), default=date.today()) or date.today()
+    end = _date(request.form.get("end"), default=start) or start
+    if end < start:
+        start, end = end, start
+    if (end - start).days > 31:
+        flash("一次最多產生 32 天的採購草稿。", "error")
+        return redirect(url_for("order_tool.purchases", start=start, end=end))
+
+    created = 0
+    blocked_dates = []
+    day = start
+    while day <= end:
+        count, blocked = _generate_date_orders(day)
+        created += count
+        if blocked:
+            blocked_dates.append(str(day))
+        day += timedelta(days=1)
+
+    if created:
+        flash(f"已建立 / 更新 {created} 張採購草稿。", "success")
+    if blocked_dates:
+        flash("以下日期已有已確認採購單，因此沒有自動重算：" + "、".join(blocked_dates), "warning")
+    if not created and not blocked_dates:
+        flash("此期間沒有可計算的菜單需求。請確認菜色配方與學校人數。", "warning")
+    return redirect(url_for("order_tool.purchases", start=start, end=end))
+
+
+@order_bp.get("/purchases/<int:order_id>")
+def purchase_detail(order_id: int):
+    order = db.session.get(KitchenPurchaseOrder, order_id)
+    if not order:
+        abort(404)
+    suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.active.desc(), KitchenSupplier.name).all()
     do_print = request.args.get("print") == "1"
-    body = r"""
-<div class="top"><div><h1>採購叫貨表</h1><div class="muted">{{ start }} ～ {{ end }}</div></div>
-<div class="row no-print"><form method="get" class="row"><div class="field"><label>開始</label><input name="start" type="date" value="{{ start }}"></div>
-<div class="field"><label>結束</label><input name="end" type="date" value="{{ end }}"></div><button class="btn secondary">重新計算</button></form>
-<a class="btn" href="{{ url_for('order_tool.purchase', start=start, end=end, print=1) }}" target="_blank">列印 / 另存 PDF</a></div></div>
-{% if missing_supplier %}<div class="notice no-print">有 {{ missing_supplier }} 個日期×供應商群組包含未指定供應商食材，請先回「食材」補上廠商。</div>{% endif %}
-<section class="card"><h2>供餐摘要</h2>{% if summaries %}<table><tr><th>日期</th><th>餐別</th><th>菜單</th><th class="right">學校</th><th class="right">人數</th></tr>
-{% for s in summaries %}<tr><td>{{ s.date }}</td><td>{{ s.meal_type }}</td><td>{{ s.name }}</td><td class="right">{{ s.schools }}</td><td class="right">{{ s.people }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">此期間沒有菜單。</div>{% endif %}</section><br>
-{% if groups %}{% for g in groups %}<section class="card purchase-group"><div class="top"><div><h2>{{ g.date }}｜{{ g.supplier }}</h2></div><div><b>小計 ${{ '%.2f'|format(g.cost|float) }}</b></div></div>
-<table><tr><th>食材</th><th class="right">需求量</th><th class="right">單價/kg</th><th class="right">預估金額</th></tr>
-{% for r in g.rows %}<tr><td>{{ r.ingredient }}</td><td class="right"><b>{{ '%.3f'|format(r.kg|float) }} kg</b></td><td class="right">${{ '%.2f'|format(r.unit_price|float) }}</td><td class="right">${{ '%.2f'|format(r.cost|float) }}</td></tr>{% endfor %}</table></section><br>{% endfor %}
-<section class="card"><div class="right"><h2>預估採購總額：${{ '%.2f'|format(total_cost|float) }}</h2></div></section>
-{% elif summaries %}<section class="card"><div class="empty">有菜單，但尚未產生採購量。請確認：菜單有菜色、菜色有配方、菜單已分配學校與人數。</div></section>{% endif %}
-{% if do_print %}<script>window.addEventListener('load',()=>window.print());</script>{% endif %}
-"""
-    return _render(
-        "採購叫貨表",
-        body,
-        start=start,
-        end=end,
-        groups=groups,
-        summaries=summaries,
-        total_cost=total_cost,
-        missing_supplier=missing_supplier,
+    return render_template(
+        "kitchen/purchase_detail.html",
+        order=order,
+        suppliers=suppliers_all,
+        total=_order_total(order),
         do_print=do_print,
     )
+
+
+@order_bp.post("/purchases/<int:order_id>/update")
+def purchase_update(order_id: int):
+    order = db.session.get(KitchenPurchaseOrder, order_id)
+    if not order:
+        abort(404)
+    if order.status != "draft":
+        flash("只有草稿採購單可以修改。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+
+    supplier_id = _int(request.form.get("supplier_id"), default=None)
+    if supplier_id is not None:
+        supplier = db.session.get(KitchenSupplier, supplier_id)
+        if not supplier:
+            flash("找不到指定廠商。", "error")
+            return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+        new_key = f"supplier:{supplier.id}"
+        new_name = supplier.name
+    else:
+        supplier = None
+        new_key = "unassigned"
+        new_name = "⚠ 未指定供應商"
+
+    conflict = KitchenPurchaseOrder.query.filter(
+        KitchenPurchaseOrder.service_date == order.service_date,
+        KitchenPurchaseOrder.supplier_key == new_key,
+        KitchenPurchaseOrder.id != order.id,
+    ).first()
+    if conflict:
+        flash("同一天已存在這個廠商的採購單，請先處理該單，避免重複叫貨。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+
+    order.supplier_id = supplier.id if supplier else None
+    order.supplier_key = new_key
+    order.supplier_name_snapshot = new_name
+    order.note = request.form.get("note", "").strip() or None
+    return _commit("採購單資料已更新。", "order_tool.purchase_detail", order_id=order_id)
+
+
+@order_bp.post("/purchase-items/<int:item_id>/update")
+def purchase_item_update(item_id: int):
+    item = db.session.get(KitchenPurchaseOrderItem, item_id)
+    if not item:
+        abort(404)
+    if item.order.status != "draft":
+        flash("已確認的採購單不可直接修改。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=item.order_id))
+    actual = _decimal(request.form.get("actual_order_qty"))
+    price = _decimal(request.form.get("unit_price"))
+    if actual is None or actual < 0 or price is None or price < 0:
+        flash("實際叫貨量與單價不可為負數。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=item.order_id))
+    item.actual_order_qty = actual
+    item.unit_price_snapshot = price
+    item.amount = actual * price
+    item.note = request.form.get("note", "").strip() or None
+    db.session.commit()
+    flash("採購項目已更新。", "success")
+    return redirect(url_for("order_tool.purchase_detail", order_id=item.order_id))
+
+
+@order_bp.post("/purchases/<int:order_id>/confirm")
+def purchase_confirm(order_id: int):
+    order = db.session.get(KitchenPurchaseOrder, order_id)
+    if not order:
+        abort(404)
+    if order.status != "draft":
+        flash("這張採購單目前不是草稿。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+    if not order.items:
+        flash("空白採購單不可確認。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+    if not order.supplier_id:
+        flash("正式確認前必須指定供應商。", "error")
+        return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+
+    order.status = "confirmed"
+    # 確認任何正式採購時，同日菜單一起鎖定，防止操作人員誤以為改菜單會改掉已下單內容。
+    for plan in KitchenMenuPlan.query.filter_by(service_date=order.service_date).all():
+        plan.status = "confirmed"
+    db.session.commit()
+    flash("採購單已確認並保存歷史 snapshot。", "success")
+    return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+
+
+@order_bp.post("/purchases/<int:order_id>/reopen")
+def purchase_reopen(order_id: int):
+    order = db.session.get(KitchenPurchaseOrder, order_id)
+    if not order:
+        abort(404)
+    order.status = "draft"
+    db.session.commit()
+    flash("採購單已重開草稿。既有 snapshot 數字仍保留，除非你重新按產生草稿。", "warning")
+    return redirect(url_for("order_tool.purchase_detail", order_id=order_id))
+
+
+@order_bp.post("/purchases/<int:order_id>/cancel")
+def purchase_cancel(order_id: int):
+    order = db.session.get(KitchenPurchaseOrder, order_id)
+    if not order:
+        abort(404)
+    order.status = "cancelled"
+    db.session.commit()
+    flash("採購單已取消，歷史資料仍保留。", "warning")
+    return redirect(url_for("order_tool.purchase_detail", order_id=order_id))

--- a/blueprints/order_tool.py
+++ b/blueprints/order_tool.py
@@ -1,361 +1,547 @@
-﻿"""叫貨 Excel 篩選工具 Blueprint。"""
+"""團膳菜單 / 配方 / 採購叫貨 Blueprint。
+
+流程：
+中央菜單 Plan → 指派學校與人數 → Recipe BOM（每人 AP 克數）
+→ 自動彙總食材 → 依供應商分組 → 列印 / 另存 PDF。
+"""
 
 from __future__ import annotations
 
-import io
-import re
-import uuid
-from datetime import datetime
-from typing import List, Sequence, Tuple, Optional
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from decimal import Decimal
 
-import pandas as pd
-from flask import Blueprint, abort, render_template_string, request, send_file
+from flask import Blueprint, abort, redirect, render_template_string, request, url_for
+from sqlalchemy.exc import IntegrityError
 
-# Excel 欄位群組起點，對應原本的 1,7,13,19,25...
-GROUP_STARTS: Sequence[int] = (1, 7, 13, 19, 25)
-HEADER_SCAN_ROWS = 6
-HEADER_SKIP_VALUES = {"廠商"}
-DATE_FORMATS = ("%Y-%m-%d", "%Y/%m/%d", "%m-%d", "%m/%d")
-WEEKDAY_LABELS = ("一", "二", "三", "四", "五", "六", "日")
-CURRENT_YEAR = datetime.now().year
+from extensions import db
+from models import (
+    KitchenIngredient,
+    KitchenMenuAssignment,
+    KitchenMenuPlan,
+    KitchenMenuPlanItem,
+    KitchenRecipe,
+    KitchenRecipeIngredient,
+    KitchenSchool,
+    KitchenSupplier,
+)
 
-# 暫存轉出的 Excel，讓使用者可以下載。
-RESULT_CACHE: dict[str, bytes] = {}
 
 order_bp = Blueprint("order_tool", __name__)
 
-HTML_TEMPLATE = """
-<!doctype html>
-<html lang="zh-Hant">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>叫貨 Excel 篩選器</title>
-    <style>
-      body { font-family: "Segoe UI","Microsoft JhengHei",sans-serif; background:#f5f6fa; margin:0; color:#1f2328; }
-      .container { max-width:760px; margin:0 auto; padding:32px 20px 48px; }
-      form, .card { background:#fff; border-radius:12px; padding:24px; box-shadow:0 2px 8px rgba(31,35,40,.08); margin-bottom:24px; }
-      label { font-weight:600; display:block; margin-bottom:6px; }
-      input[type=file], input[type=text] { width:100%; padding:10px 12px; border:1px solid #d0d7de; border-radius:8px; margin-bottom:18px; box-sizing:border-box; }
-      button { background:#1f883d; color:#fff; border:none; border-radius:999px; padding:12px 20px; cursor:pointer; }
-      button:hover { background:#1a7f37; }
-      .alert { padding:14px 16px; border-radius:10px; margin-bottom:18px; }
-      .alert.error { background:#ffeef0; color:#9a1c1c; border:1px solid #ffc2c7; }
-      .table-wrapper { overflow-x:auto; }
-      table { width:100%; border-collapse:collapse; }
-      th, td { padding:10px; border-bottom:1px solid #d8dee4; text-align:left; white-space:nowrap; }
-      th { background:#f8faff; }
-      a.download { display:inline-block; margin:12px 0 18px; color:#0969da; font-weight:600; text-decoration:none; }
-    </style>
-  </head>
-  <body>
-    <main class="container">
-      <h1>叫貨 Excel 篩選器（網頁版）</h1>
 
-      <form method="post" enctype="multipart/form-data">
-        <label for="excel_file">1. 上傳 Excel 檔案</label>
-        <input id="excel_file" name="excel_file" type="file" accept=".xlsx,.xls" required />
-
-        <label for="keywords">2. 輸入關鍵字（逗號分隔）</label>
-        <input id="keywords" name="keywords" type="text" placeholder="例如：巨城, 士多啤梨" required />
-
-        <button type="submit">3. 篩選並輸出</button>
-      </form>
-
-      {% if error %}
-      <div class="alert error">{{ error }}</div>
-      {% endif %}
-
-      {% if result_rows %}
-      <section class="card">
-        <h2>共找到 {{ result_rows|length }} 筆資料</h2>
-        <p>關鍵字：{{ keywords|join("、") }}</p>
-        <a class="download" href="{{ url_for('order_tool.download', token=download_id) }}">下載結果 Excel</a>
-
-        <div class="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>工作表</th>
-                <th>要吃的日期</th>
-                <th>菜名</th>
-                <th>訂貨廠商</th>
-                <th>品名-製造商</th>
-                <th>1箱g數</th>
-                <th>數量</th>
-                <th>單位</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in result_rows %}
-              <tr>
-                <td>{{ row["工作表"] }}</td>
-                <td>{{ row["要吃的日期"] }}</td>
-                <td>{{ row["菜名"] }}</td>
-                <td>{{ row["訂貨廠商"] }}</td>
-                <td>{{ row["品名-製造商"] }}</td>
-                <td>{{ row["1箱g"] }}</td>
-                <td>{{ row["數量"] }}</td>
-                <td>{{ row["單位"] }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </section>
-      {% endif %}
-    </main>
-  </body>
-</html>
+STYLE = r"""
+<style>
+:root{
+  --bg:#f5f7fb;--card:#fff;--text:#17202a;--muted:#667085;--line:#e5e7eb;
+  --brand:#1769aa;--brand2:#0f5b91;--danger:#b42318;--ok:#157347;
+}
+*{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans TC","Microsoft JhengHei",sans-serif}
+a{color:var(--brand);text-decoration:none}.wrap{max-width:1180px;margin:auto;padding:24px}
+.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px;flex-wrap:wrap}
+h1{font-size:26px;margin:0}h2{font-size:20px;margin:0 0 14px}h3{font-size:17px;margin:0 0 10px}
+.nav{display:flex;gap:8px;flex-wrap:wrap}.nav a,.btn{display:inline-block;border:0;border-radius:10px;
+padding:9px 14px;background:var(--brand);color:#fff;cursor:pointer;font-size:14px}.nav a:hover,.btn:hover{background:var(--brand2)}
+.btn.secondary{background:#eef3f8;color:#24445f}.btn.danger{background:#fff0ee;color:var(--danger)}
+.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}.span-4{grid-column:span 4}.span-5{grid-column:span 5}
+.span-6{grid-column:span 6}.span-7{grid-column:span 7}.span-8{grid-column:span 8}.span-12{grid-column:span 12}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px;box-shadow:0 2px 8px rgba(16,24,40,.04)}
+.stat{font-size:30px;font-weight:750}.muted{color:var(--muted);font-size:13px}.row{display:flex;gap:10px;align-items:end;flex-wrap:wrap}
+.field{display:flex;flex-direction:column;gap:5px;min-width:150px;flex:1}label{font-size:13px;color:#475467;font-weight:600}
+input,select,textarea{width:100%;padding:9px 10px;border:1px solid #cfd6df;border-radius:9px;background:#fff;font:inherit}
+table{width:100%;border-collapse:collapse}th,td{padding:10px 8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top;font-size:14px}
+th{font-size:12px;color:#667085;background:#fafbfc}.right{text-align:right}.pill{display:inline-block;background:#eef6ff;color:#175c91;border-radius:999px;padding:3px 8px;font-size:12px}
+.empty{padding:28px;text-align:center;color:#667085}.inline{display:inline}.notice{padding:10px 12px;border-radius:10px;background:#fff8e6;color:#7a4b00;margin-bottom:14px}
+@media(max-width:800px){.span-4,.span-5,.span-6,.span-7,.span-8{grid-column:span 12}.wrap{padding:14px}table{display:block;overflow-x:auto;white-space:nowrap}}
+@media print{body{background:#fff}.no-print{display:none!important}.wrap{max-width:none;padding:0}.card{box-shadow:none;border:0;padding:0}table{display:table;white-space:normal}th,td{font-size:11px;padding:5px}.purchase-group{break-inside:avoid;margin-bottom:22px}h1{font-size:20px}h2{font-size:16px}}
+</style>
 """
 
 
-def _detect_group_date(df: pd.DataFrame, start: int) -> str:
-    """Return the label/date that sits on top of a 5-column group."""
-
-    if start >= df.shape[1]:
-        return ""
-
-    limit = min(HEADER_SCAN_ROWS, len(df))
-    candidates: list[str] = []
-
-    for cell in df.iloc[:limit, start]:
-        if pd.isna(cell):
-            continue
-
-        if isinstance(cell, datetime):
-            text = cell.strftime("%Y-%m-%d")
-        else:
-            text = str(cell).strip()
-
-        if not text:
-            continue
-
-        if any(marker in text for marker in ("月", "日", "/", "-")):
-            return text
-
-        if text in HEADER_SKIP_VALUES or text.startswith("用餐"):
-            continue
-
-        candidates.append(text)
-
-    return candidates[0] if candidates else ""
+NAV = r"""
+<div class="top no-print">
+  <h1>團膳管理</h1>
+  <div class="nav">
+    <a href="{{ url_for('order_tool.index') }}">總覽</a>
+    <a href="{{ url_for('order_tool.plans') }}">菜單</a>
+    <a href="{{ url_for('order_tool.recipes') }}">菜色配方</a>
+    <a href="{{ url_for('order_tool.ingredients') }}">食材</a>
+    <a href="{{ url_for('order_tool.schools') }}">學校</a>
+    <a href="{{ url_for('order_tool.suppliers') }}">廠商</a>
+    <a href="{{ url_for('order_tool.purchase') }}">採購叫貨</a>
+  </div>
+</div>
+"""
 
 
-def _parse_date_components(value: str) -> Optional[Tuple[int, int, int]]:
-    if not value:
-        return None
-
-    text = str(value).strip()
-    if not text:
-        return None
-
-    for fmt in DATE_FORMATS:
-        try:
-            dt = datetime.strptime(text, fmt)
-        except ValueError:
-            continue
-
-        year = dt.year if "%Y" in fmt else CURRENT_YEAR
-        return year, dt.month, dt.day
-
-    match = re.search(r"(\d{4})\D+(\d{1,2})\D+(\d{1,2})", text)
-    if match:
-        year, month, day = map(int, match.groups())
-        return year, month, day
-
-    match = re.search(r"(\d{1,2})\s*月\s*(\d{1,2})", text)
-    if match:
-        month, day = map(int, match.groups())
-        return CURRENT_YEAR, month, day
-
-    numbers = [int(n) for n in re.findall(r"\d+", text)]
-    if len(numbers) >= 3:
-        year, month, day = numbers[:3]
-        return year, month, day
-    if len(numbers) == 2:
-        month, day = numbers
-        return CURRENT_YEAR, month, day
-    if len(numbers) == 1:
-        day = numbers[0]
-        return CURRENT_YEAR, 1, day
-
-    return None
+def _render(title: str, body: str, **ctx):
+    template = f"""<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>{title}</title>{STYLE}</head>
+<body><main class="wrap">{NAV}{body}</main></body></html>"""
+    return render_template_string(template, **ctx)
 
 
-def _format_date_display(value: str) -> Tuple[str, Optional[Tuple[int, int, int]]]:
-    components = _parse_date_components(value)
-    text = (value or "").strip()
-
-    if not components:
-        return text, None
-
-    year, month, day = components
+def _to_decimal(raw: str | None, default: str = "0") -> Decimal:
     try:
-        dt = datetime(year, month, day)
-    except ValueError:
-        return text or f"{year:04d}-{month:02d}-{day:02d}", components
-
-    has_week = bool(re.search(r"(週|星期|禮拜|\([一二三四五六日]\))", text))
-    base = text or dt.strftime("%Y-%m-%d")
-    if not has_week:
-        base = f"{base} ({WEEKDAY_LABELS[dt.weekday()]})"
-
-    return base, components
+        return Decimal((raw or default).strip())
+    except Exception:
+        return Decimal(default)
 
 
-def _row_sort_key(row: dict) -> Tuple[int, int, int, str, str, str]:
-    token = row.get("__date_token")
-    if token:
-        year, month, day = token
-    else:
-        year, month, day = (9999, 99, 99)
+def _to_int(raw: str | None, default: int = 0) -> int:
+    try:
+        return int(raw or default)
+    except Exception:
+        return default
 
-    return (
-        year,
-        month,
-        day,
-        row.get("工作表", ""),
-        str(row.get("訂貨廠商", "")),
-        str(row.get("品名-製造商", "")),
+
+def _parse_date(raw: str | None, fallback: date | None = None) -> date:
+    if raw:
+        try:
+            return datetime.strptime(raw, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    return fallback or date.today()
+
+
+def _commit_or_back(endpoint: str, **values):
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        abort(409, description="資料重複，請確認名稱或同日設定是否已存在。")
+    return redirect(url_for(endpoint, **values))
+
+
+@order_bp.get("/")
+def index():
+    today = date.today()
+    week_end = today + timedelta(days=6)
+    plans = (
+        KitchenMenuPlan.query
+        .filter(KitchenMenuPlan.service_date.between(today, week_end))
+        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
+        .all()
+    )
+    body = r"""
+<div class="grid">
+  <section class="card span-4"><div class="muted">菜色配方</div><div class="stat">{{ recipe_count }}</div></section>
+  <section class="card span-4"><div class="muted">食材</div><div class="stat">{{ ingredient_count }}</div></section>
+  <section class="card span-4"><div class="muted">供餐學校</div><div class="stat">{{ school_count }}</div></section>
+  <section class="card span-12">
+    <div class="top"><div><h2>未來 7 天菜單</h2><div class="muted">一份中央菜單可以同時指派多間學校與各自人數。</div></div>
+    <a class="btn" href="{{ url_for('order_tool.plans') }}">新增菜單</a></div>
+    {% if plans %}<table><thead><tr><th>日期</th><th>餐別</th><th>名稱</th><th>菜色</th><th>學校 / 人數</th><th></th></tr></thead><tbody>
+    {% for p in plans %}<tr><td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name or '中央菜單' }}</td>
+      <td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td>
+      <td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">編輯</a></td></tr>{% endfor %}
+    </tbody></table>{% else %}<div class="empty">這 7 天還沒有菜單。</div>{% endif %}
+  </section>
+</div>"""
+    return _render(
+        "團膳管理",
+        body,
+        plans=plans,
+        recipe_count=KitchenRecipe.query.count(),
+        ingredient_count=KitchenIngredient.query.count(),
+        school_count=KitchenSchool.query.filter_by(active=True).count(),
     )
 
 
-def parse_keywords(raw: str) -> List[str]:
-    return [kw.strip() for kw in raw.split(",") if kw.strip()]
+@order_bp.route("/schools", methods=["GET", "POST"])
+def schools():
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        if not name:
+            abort(400, description="學校名稱不可空白。")
+        db.session.add(KitchenSchool(name=name, code=request.form.get("code", "").strip() or None))
+        return _commit_or_back("order_tool.schools")
+
+    rows = KitchenSchool.query.order_by(KitchenSchool.name).all()
+    body = r"""
+<div class="grid"><section class="card span-5"><h2>新增學校 / 客戶</h2>
+<form method="post"><div class="field"><label>名稱</label><input name="name" required placeholder="例如：內小"></div><br>
+<div class="field"><label>代碼（可空白）</label><input name="code" placeholder="例如：A01"></div><br><button class="btn">新增</button></form></section>
+<section class="card span-7"><h2>學校清單</h2>{% if rows %}<table><tr><th>代碼</th><th>名稱</th><th>狀態</th></tr>
+{% for r in rows %}<tr><td>{{ r.code or '-' }}</td><td>{{ r.name }}</td><td>{{ '啟用' if r.active else '停用' }}</td></tr>{% endfor %}</table>
+{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
+    return _render("學校", body, rows=rows)
 
 
-def _clean_cell(value):
-    if pd.isna(value):
-        return ""
-    return value
+@order_bp.route("/suppliers", methods=["GET", "POST"])
+def suppliers():
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        if not name:
+            abort(400, description="廠商名稱不可空白。")
+        db.session.add(KitchenSupplier(
+            name=name,
+            phone=request.form.get("phone", "").strip() or None,
+            note=request.form.get("note", "").strip() or None,
+        ))
+        return _commit_or_back("order_tool.suppliers")
+
+    rows = KitchenSupplier.query.order_by(KitchenSupplier.name).all()
+    body = r"""
+<div class="grid"><section class="card span-5"><h2>新增廠商</h2><form method="post">
+<div class="field"><label>廠商名稱</label><input name="name" required></div><br><div class="field"><label>電話</label><input name="phone"></div><br>
+<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">新增</button></form></section>
+<section class="card span-7"><h2>廠商清單</h2>{% if rows %}<table><tr><th>廠商</th><th>電話</th><th>備註</th></tr>
+{% for r in rows %}<tr><td>{{ r.name }}</td><td>{{ r.phone or '-' }}</td><td>{{ r.note or '-' }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
+    return _render("廠商", body, rows=rows)
 
 
-def filter_workbook(xls: pd.ExcelFile, keywords: Sequence[str]) -> list[dict]:
-    lowered = [kw.lower() for kw in keywords]
-    rows: list[dict] = []
+@order_bp.route("/ingredients", methods=["GET", "POST"])
+def ingredients():
+    suppliers_all = KitchenSupplier.query.order_by(KitchenSupplier.name).all()
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        if not name:
+            abort(400, description="食材名稱不可空白。")
+        supplier_id = _to_int(request.form.get("supplier_id")) or None
+        db.session.add(KitchenIngredient(
+            name=name,
+            unit_price=_to_decimal(request.form.get("unit_price")),
+            supplier_id=supplier_id,
+            note=request.form.get("note", "").strip() or None,
+        ))
+        return _commit_or_back("order_tool.ingredients")
 
-    for sheet in xls.sheet_names:
-        df = pd.read_excel(xls, sheet_name=sheet)
-        if df.empty:
+    rows = KitchenIngredient.query.order_by(KitchenIngredient.name).all()
+    body = r"""
+<div class="grid"><section class="card span-5"><h2>新增食材</h2><div class="muted">配方一律以「每人幾克」儲存；單價預設為每公斤。</div><br>
+<form method="post"><div class="field"><label>食材名稱</label><input name="name" required placeholder="骨腿丁"></div><br>
+<div class="field"><label>單價 / kg</label><input name="unit_price" type="number" step="0.0001" value="0"></div><br>
+<div class="field"><label>預設供應商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}">{{ s.name }}</option>{% endfor %}</select></div><br>
+<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">新增</button></form></section>
+<section class="card span-7"><h2>食材清單</h2>{% if rows %}<table><tr><th>食材</th><th class="right">單價/kg</th><th>供應商</th></tr>
+{% for r in rows %}<tr><td>{{ r.name }}</td><td class="right">${{ '%.2f'|format(r.unit_price|float) }}</td><td>{{ r.supplier.name if r.supplier else '⚠ 未指定' }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">尚無資料</div>{% endif %}</section></div>"""
+    return _render("食材", body, rows=rows, suppliers=suppliers_all)
+
+
+@order_bp.route("/recipes", methods=["GET", "POST"])
+def recipes():
+    if request.method == "POST":
+        name = request.form.get("name", "").strip()
+        if not name:
+            abort(400, description="菜色名稱不可空白。")
+        output_raw = request.form.get("serving_output_g", "").strip()
+        recipe = KitchenRecipe(
+            name=name,
+            category=request.form.get("category", "").strip() or None,
+            serving_output_g=_to_decimal(output_raw) if output_raw else None,
+            note=request.form.get("note", "").strip() or None,
+        )
+        db.session.add(recipe)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            abort(409, description="菜色名稱已存在。")
+        return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe.id))
+
+    rows = KitchenRecipe.query.order_by(KitchenRecipe.category, KitchenRecipe.name).all()
+    body = r"""
+<div class="grid"><section class="card span-5"><h2>新增菜色</h2><form method="post">
+<div class="field"><label>菜色名稱</label><input name="name" required placeholder="南洋綠咖哩雞"></div><br>
+<div class="field"><label>分類</label><select name="category"><option>主食</option><option selected>主菜</option><option>副菜</option><option>青菜</option><option>湯品</option><option>點心</option></select></div><br>
+<div class="field"><label>預計打菜量 g / 人（可空白）</label><input name="serving_output_g" type="number" step="0.01" placeholder="95"></div><br>
+<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">建立後設定配方</button></form></section>
+<section class="card span-7"><h2>菜色配方</h2>{% if rows %}<table><tr><th>類別</th><th>菜色</th><th class="right">生料 g/人</th><th class="right">打菜 g/人</th><th></th></tr>
+{% for r in rows %}<tr><td><span class="pill">{{ r.category or '未分類' }}</span></td><td>{{ r.name }}</td><td class="right">{{ '%.1f'|format(r.ingredients|sum(attribute='grams_per_person')|float) }}</td>
+<td class="right">{{ '%.1f'|format(r.serving_output_g|float) if r.serving_output_g is not none else '-' }}</td><td><a href="{{ url_for('order_tool.recipe_detail', recipe_id=r.id) }}">編輯配方</a></td></tr>{% endfor %}</table>
+{% else %}<div class="empty">先建立第一道菜。</div>{% endif %}</section></div>"""
+    return _render("菜色配方", body, rows=rows)
+
+
+@order_bp.route("/recipes/<int:recipe_id>", methods=["GET"])
+def recipe_detail(recipe_id: int):
+    recipe = db.session.get(KitchenRecipe, recipe_id)
+    if not recipe:
+        abort(404)
+    ingredients_all = KitchenIngredient.query.order_by(KitchenIngredient.name).all()
+    total_g = sum((x.grams_per_person or 0) for x in recipe.ingredients)
+    total_cost = sum(
+        ((x.grams_per_person or 0) / Decimal("1000")) * (x.ingredient.unit_price or 0)
+        for x in recipe.ingredients
+    )
+    body = r"""
+<div class="top"><div><h1>{{ recipe.name }}</h1><div class="muted">每人配方（AP 採購量）</div></div><a class="btn secondary" href="{{ url_for('order_tool.recipes') }}">← 回菜色清單</a></div>
+<div class="grid"><section class="card span-7"><h2>目前配方</h2>
+{% if recipe.ingredients %}<table><tr><th>食材</th><th class="right">每人 AP</th><th class="right">單價/kg</th><th class="right">每人成本</th><th></th></tr>
+{% for x in recipe.ingredients %}<tr><td>{{ x.ingredient.name }}</td><td class="right">{{ '%.3f'|format(x.grams_per_person|float) }} g</td>
+<td class="right">${{ '%.2f'|format(x.ingredient.unit_price|float) }}</td><td class="right">${{ '%.3f'|format((x.grams_per_person|float/1000)*(x.ingredient.unit_price|float)) }}</td>
+<td><form class="inline" method="post" action="{{ url_for('order_tool.recipe_ingredient_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}</table>
+<div class="row" style="margin-top:14px"><div><b>每份生料：{{ '%.1f'|format(total_g|float) }} g</b></div><div><b>每份成本：約 ${{ '%.2f'|format(total_cost|float) }}</b></div>
+{% if recipe.serving_output_g is not none %}<div><b>打菜量：{{ recipe.serving_output_g }} g</b></div>{% endif %}</div>
+{% else %}<div class="empty">還沒有食材。</div>{% endif %}</section>
+<section class="card span-5"><h2>加入食材</h2>{% if ingredients %}<form method="post" action="{{ url_for('order_tool.recipe_ingredient_add', recipe_id=recipe.id) }}">
+<div class="field"><label>食材</label><select name="ingredient_id" required>{% for i in ingredients %}<option value="{{ i.id }}">{{ i.name }}</option>{% endfor %}</select></div><br>
+<div class="field"><label>每人採購量（g）</label><input name="grams_per_person" type="number" min="0.001" step="0.001" required placeholder="例如 88"></div><br><button class="btn">加入配方</button></form>
+{% else %}<div class="notice">請先到「食材」建立食材。</div><a class="btn" href="{{ url_for('order_tool.ingredients') }}">去建立食材</a>{% endif %}</section></div>"""
+    return _render(
+        recipe.name,
+        body,
+        recipe=recipe,
+        ingredients=ingredients_all,
+        total_g=total_g,
+        total_cost=total_cost,
+    )
+
+
+@order_bp.post("/recipes/<int:recipe_id>/ingredients")
+def recipe_ingredient_add(recipe_id: int):
+    if not db.session.get(KitchenRecipe, recipe_id):
+        abort(404)
+    ingredient_id = _to_int(request.form.get("ingredient_id"))
+    grams = _to_decimal(request.form.get("grams_per_person"))
+    if ingredient_id <= 0 or grams <= 0:
+        abort(400, description="食材與克數不正確。")
+    existing = KitchenRecipeIngredient.query.filter_by(recipe_id=recipe_id, ingredient_id=ingredient_id).first()
+    if existing:
+        existing.grams_per_person = grams
+    else:
+        db.session.add(KitchenRecipeIngredient(
+            recipe_id=recipe_id,
+            ingredient_id=ingredient_id,
+            grams_per_person=grams,
+        ))
+    db.session.commit()
+    return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
+
+
+@order_bp.post("/recipe-ingredients/<int:row_id>/delete")
+def recipe_ingredient_delete(row_id: int):
+    row = db.session.get(KitchenRecipeIngredient, row_id)
+    if not row:
+        abort(404)
+    recipe_id = row.recipe_id
+    db.session.delete(row)
+    db.session.commit()
+    return redirect(url_for("order_tool.recipe_detail", recipe_id=recipe_id))
+
+
+@order_bp.route("/plans", methods=["GET", "POST"])
+def plans():
+    if request.method == "POST":
+        service_date = _parse_date(request.form.get("service_date"))
+        plan = KitchenMenuPlan(
+            service_date=service_date,
+            meal_type=request.form.get("meal_type", "午餐").strip() or "午餐",
+            name=request.form.get("name", "").strip() or "中央菜單",
+            note=request.form.get("note", "").strip() or None,
+        )
+        db.session.add(plan)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            abort(409, description="同一天、同餐別、同名稱的菜單已存在。")
+        return redirect(url_for("order_tool.plan_detail", plan_id=plan.id))
+
+    start = _parse_date(request.args.get("start"), date.today())
+    end = start + timedelta(days=13)
+    rows = (
+        KitchenMenuPlan.query
+        .filter(KitchenMenuPlan.service_date.between(start, end))
+        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
+        .all()
+    )
+    body = r"""
+<div class="grid"><section class="card span-5"><h2>建立中央菜單</h2><form method="post">
+<div class="field"><label>供餐日期</label><input name="service_date" type="date" value="{{ today }}" required></div><br>
+<div class="field"><label>餐別</label><select name="meal_type"><option selected>午餐</option><option>早餐</option><option>晚餐</option><option>點心</option></select></div><br>
+<div class="field"><label>菜單名稱</label><input name="name" value="中央菜單" placeholder="例如 A 菜單"></div><br>
+<div class="field"><label>備註</label><input name="note"></div><br><button class="btn">建立並排菜</button></form></section>
+<section class="card span-7"><div class="top"><h2>{{ start }} 起 14 天</h2><form method="get" class="row"><input name="start" type="date" value="{{ start }}"><button class="btn secondary">查看</button></form></div>
+{% if rows %}<table><tr><th>日期</th><th>餐別</th><th>菜單</th><th>菜色</th><th>供餐</th><th></th></tr>
+{% for p in rows %}<tr><td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name }}</td><td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td>
+<td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">編輯</a></td></tr>{% endfor %}</table>{% else %}<div class="empty">這段期間沒有菜單。</div>{% endif %}</section></div>"""
+    return _render("菜單", body, rows=rows, start=start, today=date.today().isoformat())
+
+
+@order_bp.get("/plans/<int:plan_id>")
+def plan_detail(plan_id: int):
+    plan = db.session.get(KitchenMenuPlan, plan_id)
+    if not plan:
+        abort(404)
+    recipes_all = KitchenRecipe.query.order_by(KitchenRecipe.category, KitchenRecipe.name).all()
+    schools_all = KitchenSchool.query.filter_by(active=True).order_by(KitchenSchool.name).all()
+    total_people = sum(x.headcount for x in plan.assignments)
+    body = r"""
+<div class="top"><div><h1>{{ plan.service_date }}・{{ plan.meal_type }}・{{ plan.name }}</h1><div class="muted">先排菜，再指派學校與該日人數。</div></div>
+<a class="btn secondary" href="{{ url_for('order_tool.plans') }}">← 回菜單</a></div>
+<div class="grid"><section class="card span-6"><h2>① 今日菜色</h2>{% if plan.items %}<table><tr><th>類別</th><th>菜色</th><th>生料 g/人</th><th></th></tr>
+{% for x in plan.items %}<tr><td>{{ x.recipe.category or '-' }}</td><td>{{ x.recipe.name }}</td><td>{{ '%.1f'|format(x.recipe.ingredients|sum(attribute='grams_per_person')|float) }}</td>
+<td><form class="inline" method="post" action="{{ url_for('order_tool.plan_item_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}</table>{% else %}<div class="empty">尚未排菜。</div>{% endif %}
+<hr style="border:0;border-top:1px solid #eee;margin:18px 0"><h3>加入菜色</h3>{% if recipes %}<form method="post" action="{{ url_for('order_tool.plan_item_add', plan_id=plan.id) }}" class="row">
+<div class="field"><select name="recipe_id">{% for r in recipes %}<option value="{{ r.id }}">{{ r.category or '未分類' }}｜{{ r.name }}</option>{% endfor %}</select></div><button class="btn">加入</button></form>{% else %}<div class="notice">請先建立菜色配方。</div>{% endif %}</section>
+<section class="card span-6"><h2>② 分配學校 / 人數</h2>{% if plan.assignments %}<table><tr><th>學校</th><th class="right">人數</th><th></th></tr>
+{% for x in plan.assignments %}<tr><td>{{ x.school.name }}</td><td class="right">{{ x.headcount }}</td><td><form class="inline" method="post" action="{{ url_for('order_tool.assignment_delete', row_id=x.id) }}"><button class="btn danger">移除</button></form></td></tr>{% endfor %}
+<tr><td><b>總人數</b></td><td class="right"><b>{{ total_people }}</b></td><td></td></tr></table>{% else %}<div class="empty">尚未分配學校。</div>{% endif %}
+<hr style="border:0;border-top:1px solid #eee;margin:18px 0"><h3>加入 / 更新學校</h3>{% if schools %}<form method="post" action="{{ url_for('order_tool.assignment_add', plan_id=plan.id) }}" class="row">
+<div class="field"><label>學校</label><select name="school_id">{% for s in schools %}<option value="{{ s.id }}">{{ s.name }}</option>{% endfor %}</select></div>
+<div class="field"><label>當日人數</label><input name="headcount" type="number" min="0" required></div><button class="btn">儲存</button></form>{% else %}<div class="notice">請先建立學校。</div>{% endif %}</section>
+<section class="card span-12"><div class="top"><div><h2>③ 試算採購</h2><div class="muted">完成菜色與學校後，可直接查看這一天要叫多少貨。</div></div>
+<a class="btn" href="{{ url_for('order_tool.purchase', start=plan.service_date, end=plan.service_date) }}">產生叫貨表</a></div></section></div>"""
+    return _render(
+        "編輯菜單",
+        body,
+        plan=plan,
+        recipes=recipes_all,
+        schools=schools_all,
+        total_people=total_people,
+    )
+
+
+@order_bp.post("/plans/<int:plan_id>/items")
+def plan_item_add(plan_id: int):
+    if not db.session.get(KitchenMenuPlan, plan_id):
+        abort(404)
+    recipe_id = _to_int(request.form.get("recipe_id"))
+    if not db.session.get(KitchenRecipe, recipe_id):
+        abort(400)
+    existing = KitchenMenuPlanItem.query.filter_by(plan_id=plan_id, recipe_id=recipe_id).first()
+    if not existing:
+        max_order = max((x.sort_order for x in KitchenMenuPlanItem.query.filter_by(plan_id=plan_id).all()), default=-1)
+        db.session.add(KitchenMenuPlanItem(plan_id=plan_id, recipe_id=recipe_id, sort_order=max_order + 1))
+        db.session.commit()
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/plan-items/<int:row_id>/delete")
+def plan_item_delete(row_id: int):
+    row = db.session.get(KitchenMenuPlanItem, row_id)
+    if not row:
+        abort(404)
+    plan_id = row.plan_id
+    db.session.delete(row)
+    db.session.commit()
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/plans/<int:plan_id>/assignments")
+def assignment_add(plan_id: int):
+    if not db.session.get(KitchenMenuPlan, plan_id):
+        abort(404)
+    school_id = _to_int(request.form.get("school_id"))
+    headcount = max(_to_int(request.form.get("headcount")), 0)
+    if not db.session.get(KitchenSchool, school_id):
+        abort(400)
+    row = KitchenMenuAssignment.query.filter_by(plan_id=plan_id, school_id=school_id).first()
+    if row:
+        row.headcount = headcount
+    else:
+        db.session.add(KitchenMenuAssignment(plan_id=plan_id, school_id=school_id, headcount=headcount))
+    db.session.commit()
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+@order_bp.post("/assignments/<int:row_id>/delete")
+def assignment_delete(row_id: int):
+    row = db.session.get(KitchenMenuAssignment, row_id)
+    if not row:
+        abort(404)
+    plan_id = row.plan_id
+    db.session.delete(row)
+    db.session.commit()
+    return redirect(url_for("order_tool.plan_detail", plan_id=plan_id))
+
+
+def _build_purchase(start: date, end: date):
+    plans = (
+        KitchenMenuPlan.query
+        .filter(KitchenMenuPlan.service_date.between(start, end))
+        .order_by(KitchenMenuPlan.service_date, KitchenMenuPlan.meal_type)
+        .all()
+    )
+
+    # key = (date, supplier_name, ingredient_id)
+    agg: dict[tuple, dict] = {}
+    plan_summaries = []
+
+    for plan in plans:
+        people = sum(max(a.headcount, 0) for a in plan.assignments)
+        plan_summaries.append({
+            "date": plan.service_date,
+            "meal_type": plan.meal_type,
+            "name": plan.name,
+            "people": people,
+            "schools": len(plan.assignments),
+        })
+        if people <= 0:
             continue
 
-        group_dates = {start: _detect_group_date(df, start) for start in GROUP_STARTS}
+        for menu_item in plan.items:
+            for component in menu_item.recipe.ingredients:
+                ing = component.ingredient
+                supplier_name = ing.supplier.name if ing.supplier else "⚠ 未指定供應商"
+                key = (plan.service_date, supplier_name, ing.id)
+                grams = (component.grams_per_person or Decimal("0")) * people
+                if key not in agg:
+                    agg[key] = {
+                        "date": plan.service_date,
+                        "supplier": supplier_name,
+                        "ingredient": ing.name,
+                        "grams": Decimal("0"),
+                        "unit_price": ing.unit_price or Decimal("0"),
+                    }
+                agg[key]["grams"] += grams
 
-        dish_history: dict[int, str] = {}
+    grouped: dict[tuple, list] = defaultdict(list)
+    for row in agg.values():
+        row["kg"] = row["grams"] / Decimal("1000")
+        row["cost"] = row["kg"] * row["unit_price"]
+        grouped[(row["date"], row["supplier"])].append(row)
 
-        for _, row in df.iterrows():
-            for start in GROUP_STARTS:
-                if start + 4 >= len(row):
-                    continue
+    groups = []
+    for (service_date, supplier), rows in sorted(grouped.items(), key=lambda x: (x[0][0], x[0][1])):
+        rows.sort(key=lambda r: r["ingredient"])
+        groups.append({
+            "date": service_date,
+            "supplier": supplier,
+            "rows": rows,
+            "cost": sum((r["cost"] for r in rows), Decimal("0")),
+        })
 
-                dish_name = ""
-                if start - 1 >= 0:
-                    cell = row.iloc[start - 1]
-                    if cell is not None and not (isinstance(cell, float) and pd.isna(cell)):
-                        candidate = str(cell).strip()
-                        if candidate:
-                            dish_history[start] = candidate
-                if dish_history.get(start):
-                    dish_name = dish_history[start]
-
-                vendor = row.iloc[start]
-                item = row.iloc[start + 1]
-                g1 = row.iloc[start + 2]
-                qty = row.iloc[start + 3]
-                unit = row.iloc[start + 4]
-
-                if pd.isna(vendor) and pd.isna(item):
-                    continue
-
-                vendor_text = "" if pd.isna(vendor) else str(vendor)
-                item_text = "" if pd.isna(item) else str(item)
-                text = f"{vendor_text} {item_text}".lower()
-                if any(kw in text for kw in lowered):
-                    raw_date = group_dates.get(start, "")
-                    display_date, token = _format_date_display(raw_date)
-                    rows.append(
-                        {
-                            "工作表": sheet,
-                            "要吃的日期": display_date,
-                            "菜名": dish_name,
-                            "訂貨廠商": _clean_cell(vendor),
-                            "品名-製造商": _clean_cell(item),
-                            "1箱g": _clean_cell(g1),
-                            "數量": _clean_cell(qty),
-                            "單位": _clean_cell(unit),
-                            "__date_token": token,
-                        }
-                    )
-
-    rows.sort(key=_row_sort_key)
-    for row in rows:
-        row.pop("__date_token", None)
-    return rows
+    total_cost = sum((g["cost"] for g in groups), Decimal("0"))
+    missing_supplier = sum(1 for g in groups if g["supplier"].startswith("⚠"))
+    return groups, plan_summaries, total_cost, missing_supplier
 
 
-@order_bp.route("/", methods=["GET", "POST"])
-def index():
-    context = {
-        "result_rows": None,
-        "keywords": [],
-        "download_id": None,
-        "error": None,
-    }
+@order_bp.get("/purchase")
+def purchase():
+    start = _parse_date(request.args.get("start"), date.today())
+    end = _parse_date(request.args.get("end"), start)
+    if end < start:
+        start, end = end, start
 
-    if request.method == "POST":
-        upload = request.files.get("excel_file")
-        raw_keywords = request.form.get("keywords", "")
-
-        if not upload or upload.filename == "":
-            context["error"] = "請選擇要處理的 Excel 檔案。"
-            return render_template_string(HTML_TEMPLATE, **context)
-
-        keywords = parse_keywords(raw_keywords)
-        if not keywords:
-            context["error"] = "請至少輸入一個關鍵字，並以逗號分隔。"
-            return render_template_string(HTML_TEMPLATE, **context)
-
-        try:
-            data = upload.read()
-            xls = pd.ExcelFile(io.BytesIO(data))
-            rows = filter_workbook(xls, keywords)
-
-            if not rows:
-                context["error"] = f"沒有找到含有 {', '.join(keywords)} 的資料。"
-                return render_template_string(HTML_TEMPLATE, **context)
-
-            result_df = pd.DataFrame(rows)
-            output = io.BytesIO()
-            result_df.to_excel(output, index=False)
-            output.seek(0)
-
-            token = uuid.uuid4().hex
-            RESULT_CACHE[token] = output.getvalue()
-
-            context.update(
-                {"result_rows": rows, "keywords": keywords, "download_id": token}
-            )
-            return render_template_string(HTML_TEMPLATE, **context)
-
-        except Exception as exc:  # noqa: BLE001
-            context["error"] = f"處理檔案時發生錯誤：{exc}"
-            return render_template_string(HTML_TEMPLATE, **context)
-
-    return render_template_string(HTML_TEMPLATE, **context)
-
-
-@order_bp.get("/download/<token>")
-def download(token: str):
-    data = RESULT_CACHE.pop(token, None)
-    if data is None:
-        abort(404)
-
-    buf = io.BytesIO(data)
-    buf.seek(0)
-    return send_file(
-        buf,
-        as_attachment=True,
-        download_name="叫貨結果.xlsx",
-        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    groups, summaries, total_cost, missing_supplier = _build_purchase(start, end)
+    do_print = request.args.get("print") == "1"
+    body = r"""
+<div class="top"><div><h1>採購叫貨表</h1><div class="muted">{{ start }} ～ {{ end }}</div></div>
+<div class="row no-print"><form method="get" class="row"><div class="field"><label>開始</label><input name="start" type="date" value="{{ start }}"></div>
+<div class="field"><label>結束</label><input name="end" type="date" value="{{ end }}"></div><button class="btn secondary">重新計算</button></form>
+<a class="btn" href="{{ url_for('order_tool.purchase', start=start, end=end, print=1) }}" target="_blank">列印 / 另存 PDF</a></div></div>
+{% if missing_supplier %}<div class="notice no-print">有 {{ missing_supplier }} 個日期×供應商群組包含未指定供應商食材，請先回「食材」補上廠商。</div>{% endif %}
+<section class="card"><h2>供餐摘要</h2>{% if summaries %}<table><tr><th>日期</th><th>餐別</th><th>菜單</th><th class="right">學校</th><th class="right">人數</th></tr>
+{% for s in summaries %}<tr><td>{{ s.date }}</td><td>{{ s.meal_type }}</td><td>{{ s.name }}</td><td class="right">{{ s.schools }}</td><td class="right">{{ s.people }}</td></tr>{% endfor %}</table>{% else %}<div class="empty">此期間沒有菜單。</div>{% endif %}</section><br>
+{% if groups %}{% for g in groups %}<section class="card purchase-group"><div class="top"><div><h2>{{ g.date }}｜{{ g.supplier }}</h2></div><div><b>小計 ${{ '%.2f'|format(g.cost|float) }}</b></div></div>
+<table><tr><th>食材</th><th class="right">需求量</th><th class="right">單價/kg</th><th class="right">預估金額</th></tr>
+{% for r in g.rows %}<tr><td>{{ r.ingredient }}</td><td class="right"><b>{{ '%.3f'|format(r.kg|float) }} kg</b></td><td class="right">${{ '%.2f'|format(r.unit_price|float) }}</td><td class="right">${{ '%.2f'|format(r.cost|float) }}</td></tr>{% endfor %}</table></section><br>{% endfor %}
+<section class="card"><div class="right"><h2>預估採購總額：${{ '%.2f'|format(total_cost|float) }}</h2></div></section>
+{% elif summaries %}<section class="card"><div class="empty">有菜單，但尚未產生採購量。請確認：菜單有菜色、菜色有配方、菜單已分配學校與人數。</div></section>{% endif %}
+{% if do_print %}<script>window.addEventListener('load',()=>window.print());</script>{% endif %}
+"""
+    return _render(
+        "採購叫貨表",
+        body,
+        start=start,
+        end=end,
+        groups=groups,
+        summaries=summaries,
+        total_cost=total_cost,
+        missing_supplier=missing_supplier,
+        do_print=do_print,
     )

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ def _database_url() -> str:
 class Config:
     # 正式環境必須在部署平台設定 SECRET_KEY。
     # 本機未設定時使用隨機值，因此重啟後 session 會失效，但不會把固定秘密放進 repo。
+    SECRET_KEY_CONFIGURED = bool(os.getenv("SECRET_KEY"))
     SECRET_KEY = os.getenv("SECRET_KEY") or os.urandom(32)
 
     SQLALCHEMY_DATABASE_URI = _database_url()

--- a/config.py
+++ b/config.py
@@ -1,42 +1,67 @@
 import os
+from datetime import timedelta
+
 BASE = os.path.abspath(os.path.dirname(__file__))
 
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _database_url() -> str:
+    url = os.getenv("DATABASE_URL", "").strip()
+    # 部分平台仍可能給 postgres://；SQLAlchemy/psycopg2 使用 postgresql://。
+    if url.startswith("postgres://"):
+        url = "postgresql://" + url[len("postgres://"):]
+    return url or f"sqlite:///{os.path.join(BASE, 'attendance.db')}"
+
+
 class Config:
-    SECRET_KEY = "change-me"
+    # 正式環境必須在部署平台設定 SECRET_KEY。
+    # 本機未設定時使用隨機值，因此重啟後 session 會失效，但不會把固定秘密放進 repo。
+    SECRET_KEY = os.getenv("SECRET_KEY") or os.urandom(32)
 
-    # 優先使用雲端 Postgres，否則退回本地 SQLite
-    SQLALCHEMY_DATABASE_URI = os.getenv(
-        "DATABASE_URL",
-        f"sqlite:///{os.path.join(BASE, 'attendance.db')}"
-    )
-
+    SQLALCHEMY_DATABASE_URI = _database_url()
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-
-    # ── SQLAlchemy 連線池設定 ──
     SQLALCHEMY_ENGINE_OPTIONS = {
         "pool_pre_ping": True,
-        "pool_recycle": 280,
+        "pool_recycle": int(os.getenv("DB_POOL_RECYCLE_SEC", "280")),
     }
+
+    PRODUCTION = _bool_env("PRODUCTION", False)
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SECURE = PRODUCTION
+    SESSION_COOKIE_SAMESITE = "Lax"
+    PERMANENT_SESSION_LIFETIME = timedelta(hours=int(os.getenv("ADMIN_SESSION_HOURS", "12")))
+
+    # 管理後台帳密不可寫死在 public repo。
+    ADMIN_HR_PASSWORD = os.getenv("ADMIN_HR_PASSWORD", "")
+    ADMIN_MGR_PASSWORD = os.getenv("ADMIN_MGR_PASSWORD", "")
+
+    # 新機器/測試環境可選擇自動建表；正式 Supabase 建議使用 migration。
+    AUTO_CREATE_DB = _bool_env("AUTO_CREATE_DB", not bool(os.getenv("DATABASE_URL")))
+
+    # 團膳後台 POST 專用 CSRF。測試可明確關閉，production 不應關閉。
+    KITCHEN_CSRF_ENABLED = _bool_env("KITCHEN_CSRF_ENABLED", True)
 
     # ─────────────────────────────────────────────
     # 打卡頁「短效 gate / token」設定（IP/UA 綁定）
     # ─────────────────────────────────────────────
-    # gate：視為「仍在現場」的有效視窗（秒）
     PUNCH_GATE_TTL_SEC = int(os.getenv("PUNCH_GATE_TTL_SEC", "120"))
-    # 一次性 token 的時效（秒）
     PUNCH_TOKEN_TTL_SEC = int(os.getenv("PUNCH_TOKEN_TTL_SEC", "120"))
-    # 是否把 IP/UA 摻入驗證（降低轉傳風險）
     PUNCH_BIND_IP = os.getenv("PUNCH_BIND_IP", "0") == "1"
     PUNCH_BIND_UA = os.getenv("PUNCH_BIND_UA", "1") == "1"
 
-    # 打卡定位圍欄（任一座標點半徑內可打卡）
     PUNCH_GEOFENCE_ENABLED = os.getenv("PUNCH_GEOFENCE_ENABLED", "1") == "1"
     PUNCH_ALLOW_RADIUS_M = float(os.getenv("PUNCH_ALLOW_RADIUS_M", "500"))
     PUNCH_REQUIRE_ACCURACY_M = float(os.getenv("PUNCH_REQUIRE_ACCURACY_M", "250"))
     PUNCH_GEOFENCE_POINTS = [
-        (24.842556724831017, 121.2107761047848),    # t1
-        (24.960056999676954, 121.30991556472662),   # 亦傑
-        (24.96919144649612, 121.33483066999854),    # 鳳小
-        (24.880557272740955, 121.18754959707424),   # t6
-        (24.10393862990907, 120.70077911082637),    # 家
+        (24.842556724831017, 121.2107761047848),
+        (24.960056999676954, 121.30991556472662),
+        (24.96919144649612, 121.33483066999854),
+        (24.880557272740955, 121.18754959707424),
+        (24.10393862990907, 120.70077911082637),
     ]

--- a/migrations/versions/kitchen20260813_prod.py
+++ b/migrations/versions/kitchen20260813_prod.py
@@ -1,0 +1,214 @@
+"""Kitchen production schema only.
+
+Revision ID: kitchen20260813
+Revises: e76227564f17
+Create Date: 2026-08-13
+
+IMPORTANT: this migration intentionally touches only kitchen_* tables.
+It must not rename/drop/alter employee or checkin tables.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "kitchen20260813"
+down_revision = "e76227564f17"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name):
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _columns(name):
+    if not _has_table(name):
+        return set()
+    return {c["name"] for c in sa.inspect(op.get_bind()).get_columns(name)}
+
+
+def _add_if_missing(table, column):
+    if column.name not in _columns(table):
+        op.add_column(table, column)
+
+
+def upgrade():
+    # School
+    if not _has_table("kitchen_school"):
+        op.create_table(
+            "kitchen_school",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(100), nullable=False, unique=True),
+            sa.Column("code", sa.String(50), unique=True),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    else:
+        _add_if_missing("kitchen_school", sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()))
+        _add_if_missing("kitchen_school", sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+        _add_if_missing("kitchen_school", sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+
+    # Supplier
+    if not _has_table("kitchen_supplier"):
+        op.create_table(
+            "kitchen_supplier",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(100), nullable=False, unique=True),
+            sa.Column("phone", sa.String(50)),
+            sa.Column("note", sa.String(255)),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    else:
+        _add_if_missing("kitchen_supplier", sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()))
+        _add_if_missing("kitchen_supplier", sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+        _add_if_missing("kitchen_supplier", sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+
+    # Ingredient. Existing MVP unit_price meant price/kg; kg defaults preserve that meaning.
+    if not _has_table("kitchen_ingredient"):
+        op.create_table(
+            "kitchen_ingredient",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(100), nullable=False, unique=True),
+            sa.Column("supplier_id", sa.Integer(), sa.ForeignKey("kitchen_supplier.id")),
+            sa.Column("purchase_unit", sa.String(20), nullable=False, server_default="kg"),
+            sa.Column("grams_per_purchase_unit", sa.Numeric(14, 3), nullable=False, server_default="1000"),
+            sa.Column("unit_price", sa.Numeric(14, 4), nullable=False, server_default="0"),
+            sa.Column("order_increment", sa.Numeric(14, 4), nullable=False, server_default="0.001"),
+            sa.Column("note", sa.String(255)),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    else:
+        _add_if_missing("kitchen_ingredient", sa.Column("purchase_unit", sa.String(20), nullable=False, server_default="kg"))
+        _add_if_missing("kitchen_ingredient", sa.Column("grams_per_purchase_unit", sa.Numeric(14, 3), nullable=False, server_default="1000"))
+        _add_if_missing("kitchen_ingredient", sa.Column("order_increment", sa.Numeric(14, 4), nullable=False, server_default="0.001"))
+        _add_if_missing("kitchen_ingredient", sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()))
+        _add_if_missing("kitchen_ingredient", sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+        _add_if_missing("kitchen_ingredient", sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+
+    # Recipe
+    if not _has_table("kitchen_recipe"):
+        op.create_table(
+            "kitchen_recipe",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(120), nullable=False, unique=True),
+            sa.Column("category", sa.String(50)),
+            sa.Column("serving_output_g", sa.Numeric(10, 2)),
+            sa.Column("note", sa.String(255)),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    else:
+        _add_if_missing("kitchen_recipe", sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()))
+        _add_if_missing("kitchen_recipe", sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+        _add_if_missing("kitchen_recipe", sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+
+    if not _has_table("kitchen_recipe_ingredient"):
+        op.create_table(
+            "kitchen_recipe_ingredient",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("recipe_id", sa.Integer(), sa.ForeignKey("kitchen_recipe.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("ingredient_id", sa.Integer(), sa.ForeignKey("kitchen_ingredient.id"), nullable=False),
+            sa.Column("grams_per_person", sa.Numeric(12, 3), nullable=False),
+            sa.UniqueConstraint("recipe_id", "ingredient_id", name="uq_kitchen_recipe_ingredient"),
+        )
+
+    # Menu
+    if not _has_table("kitchen_menu_plan"):
+        op.create_table(
+            "kitchen_menu_plan",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("service_date", sa.Date(), nullable=False, index=True),
+            sa.Column("meal_type", sa.String(30), nullable=False, server_default="午餐"),
+            sa.Column("name", sa.String(120), nullable=False, server_default="中央菜單"),
+            sa.Column("note", sa.String(255)),
+            sa.Column("status", sa.String(20), nullable=False, server_default="draft"),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint("service_date", "meal_type", "name", name="uq_kitchen_menu_plan_identity"),
+        )
+    else:
+        _add_if_missing("kitchen_menu_plan", sa.Column("status", sa.String(20), nullable=False, server_default="draft"))
+        _add_if_missing("kitchen_menu_plan", sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+        _add_if_missing("kitchen_menu_plan", sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()))
+
+    if not _has_table("kitchen_menu_plan_item"):
+        op.create_table(
+            "kitchen_menu_plan_item",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("plan_id", sa.Integer(), sa.ForeignKey("kitchen_menu_plan.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("recipe_id", sa.Integer(), sa.ForeignKey("kitchen_recipe.id"), nullable=False),
+            sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+            sa.UniqueConstraint("plan_id", "recipe_id", name="uq_kitchen_menu_plan_recipe"),
+        )
+
+    if not _has_table("kitchen_menu_assignment"):
+        op.create_table(
+            "kitchen_menu_assignment",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("plan_id", sa.Integer(), sa.ForeignKey("kitchen_menu_plan.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("school_id", sa.Integer(), sa.ForeignKey("kitchen_school.id"), nullable=False),
+            sa.Column("headcount", sa.Integer(), nullable=False, server_default="0"),
+            sa.UniqueConstraint("plan_id", "school_id", name="uq_kitchen_menu_assignment"),
+        )
+
+    # Persisted purchase orders / snapshots
+    if not _has_table("kitchen_purchase_order"):
+        op.create_table(
+            "kitchen_purchase_order",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("service_date", sa.Date(), nullable=False, index=True),
+            sa.Column("supplier_id", sa.Integer(), sa.ForeignKey("kitchen_supplier.id")),
+            sa.Column("supplier_key", sa.String(100), nullable=False),
+            sa.Column("supplier_name_snapshot", sa.String(120), nullable=False),
+            sa.Column("status", sa.String(20), nullable=False, server_default="draft"),
+            sa.Column("note", sa.String(255)),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint("service_date", "supplier_key", name="uq_kitchen_purchase_order_supplier_day"),
+        )
+
+    if not _has_table("kitchen_purchase_order_item"):
+        op.create_table(
+            "kitchen_purchase_order_item",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("order_id", sa.Integer(), sa.ForeignKey("kitchen_purchase_order.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("ingredient_id", sa.Integer(), sa.ForeignKey("kitchen_ingredient.id")),
+            sa.Column("ingredient_name_snapshot", sa.String(120), nullable=False),
+            sa.Column("required_grams", sa.Numeric(16, 3), nullable=False, server_default="0"),
+            sa.Column("required_qty", sa.Numeric(16, 4), nullable=False, server_default="0"),
+            sa.Column("purchase_unit_snapshot", sa.String(20), nullable=False),
+            sa.Column("grams_per_purchase_unit_snapshot", sa.Numeric(16, 3), nullable=False),
+            sa.Column("recommended_order_qty", sa.Numeric(16, 4), nullable=False, server_default="0"),
+            sa.Column("actual_order_qty", sa.Numeric(16, 4), nullable=False, server_default="0"),
+            sa.Column("unit_price_snapshot", sa.Numeric(16, 4), nullable=False, server_default="0"),
+            sa.Column("amount", sa.Numeric(18, 4), nullable=False, server_default="0"),
+            sa.Column("note", sa.String(255)),
+            sa.UniqueConstraint("order_id", "ingredient_id", name="uq_kitchen_purchase_order_item"),
+        )
+
+
+def downgrade():
+    # Downgrade remains kitchen-only. It intentionally never touches attendance tables.
+    for table in ("kitchen_purchase_order_item", "kitchen_purchase_order"):
+        if _has_table(table):
+            op.drop_table(table)
+
+    additions = {
+        "kitchen_menu_plan": ("updated_at", "created_at", "status"),
+        "kitchen_recipe": ("updated_at", "created_at", "active"),
+        "kitchen_ingredient": ("updated_at", "created_at", "active", "order_increment", "grams_per_purchase_unit", "purchase_unit"),
+        "kitchen_supplier": ("updated_at", "created_at", "active"),
+        "kitchen_school": ("updated_at", "created_at"),
+    }
+    for table, columns in additions.items():
+        if _has_table(table):
+            for column in columns:
+                if column in _columns(table):
+                    op.drop_column(table, column)

--- a/migrations/versions/kitchen20260814_guardrails.py
+++ b/migrations/versions/kitchen20260814_guardrails.py
@@ -1,0 +1,38 @@
+"""Add kitchen guardrail columns without touching attendance tables.
+
+Revision ID: kitchen20260814
+Revises: kitchen20260813
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "kitchen20260814"
+down_revision = "kitchen20260813"
+branch_labels = None
+depends_on = None
+
+
+def _columns(table):
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {column["name"] for column in inspector.get_columns(table)}
+
+
+def _add_if_missing(table, column):
+    if column.name not in _columns(table):
+        op.add_column(table, column)
+
+
+def upgrade():
+    _add_if_missing("kitchen_ingredient", sa.Column("base_unit", sa.String(10), nullable=False, server_default="g"))
+    _add_if_missing("kitchen_purchase_order", sa.Column("supplier_overridden", sa.Boolean(), nullable=False, server_default=sa.false()))
+    _add_if_missing("kitchen_purchase_order_item", sa.Column("base_unit_snapshot", sa.String(10), nullable=False, server_default="g"))
+    _add_if_missing("kitchen_purchase_order_item", sa.Column("manual_override", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    # Intentionally non-destructive. Kitchen production history should not be
+    # dropped automatically; rollback requires a reviewed manual migration.
+    pass

--- a/models.py
+++ b/models.py
@@ -1,22 +1,182 @@
 # models.py
 from extensions import db
 
+
 class Employee(db.Model):
-    __tablename__ = 'employee'   # 若你資料庫中表名為 employees，請改成 'employees'
-    id            = db.Column(db.Integer, primary_key=True)
-    name          = db.Column(db.String(50), nullable=False)
-    area          = db.Column(db.String(50))
+    __tablename__ = "employee"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), nullable=False)
+    area = db.Column(db.String(50))
     default_break = db.Column(db.Float, nullable=False, default=0.0)
 
+
 class Checkin(db.Model):
-    __tablename__ = 'checkin'    # 若你原本叫 checkins，請更新為一致
-    id          = db.Column(db.Integer, primary_key=True)
-    employee_id = db.Column(db.Integer, db.ForeignKey('employee.id'), nullable=False)
-    work_date   = db.Column(db.String(10), nullable=False)     
-    p_type      = db.Column(db.String(10), nullable=False)      
-    ts          = db.Column(db.String(19), nullable=False)   
-    note = db.Column(db.String(50))  # 允許輸入中文備註
-  
+    __tablename__ = "checkin"
+    id = db.Column(db.Integer, primary_key=True)
+    employee_id = db.Column(db.Integer, db.ForeignKey("employee.id"), nullable=False)
+    work_date = db.Column(db.String(10), nullable=False)
+    p_type = db.Column(db.String(10), nullable=False)
+    ts = db.Column(db.String(19), nullable=False)
+    note = db.Column(db.String(50))
+
     __table_args__ = (
-        db.UniqueConstraint('employee_id', 'work_date', 'p_type'),
+        db.UniqueConstraint("employee_id", "work_date", "p_type"),
+    )
+
+
+# ─────────────────────────────────────────────
+# 團膳 / 萬能廚師替代模組
+# 中央菜單 → 分配學校與人數 → Recipe BOM → 採購彙總
+# ─────────────────────────────────────────────
+
+
+class KitchenSchool(db.Model):
+    __tablename__ = "kitchen_school"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    code = db.Column(db.String(50), unique=True)
+    active = db.Column(db.Boolean, nullable=False, default=True)
+
+
+class KitchenSupplier(db.Model):
+    __tablename__ = "kitchen_supplier"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    phone = db.Column(db.String(50))
+    note = db.Column(db.String(255))
+
+
+class KitchenIngredient(db.Model):
+    __tablename__ = "kitchen_ingredient"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    # 採購單價預設以每 kg 計價；每人配方固定以 g 儲存
+    unit_price = db.Column(db.Numeric(12, 4), nullable=False, default=0)
+    supplier_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_supplier.id"),
+        nullable=True,
+    )
+    note = db.Column(db.String(255))
+
+    supplier = db.relationship("KitchenSupplier")
+
+
+class KitchenRecipe(db.Model):
+    __tablename__ = "kitchen_recipe"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False, unique=True)
+    category = db.Column(db.String(50))  # 主食 / 主菜 / 副菜 / 湯品 / 青菜...
+    # 成品預計每人打菜量（例如 95g）；可空白，不參與採購計算
+    serving_output_g = db.Column(db.Numeric(10, 2), nullable=True)
+    note = db.Column(db.String(255))
+
+    ingredients = db.relationship(
+        "KitchenRecipeIngredient",
+        back_populates="recipe",
+        cascade="all, delete-orphan",
+        order_by="KitchenRecipeIngredient.id",
+    )
+
+
+class KitchenRecipeIngredient(db.Model):
+    __tablename__ = "kitchen_recipe_ingredient"
+
+    id = db.Column(db.Integer, primary_key=True)
+    recipe_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_recipe.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    ingredient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_ingredient.id"),
+        nullable=False,
+    )
+    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g
+    grams_per_person = db.Column(db.Numeric(10, 3), nullable=False)
+
+    recipe = db.relationship("KitchenRecipe", back_populates="ingredients")
+    ingredient = db.relationship("KitchenIngredient")
+
+    __table_args__ = (
+        db.UniqueConstraint("recipe_id", "ingredient_id"),
+    )
+
+
+class KitchenMenuPlan(db.Model):
+    __tablename__ = "kitchen_menu_plan"
+
+    id = db.Column(db.Integer, primary_key=True)
+    service_date = db.Column(db.Date, nullable=False, index=True)
+    meal_type = db.Column(db.String(30), nullable=False, default="午餐")
+    name = db.Column(db.String(120))
+    note = db.Column(db.String(255))
+
+    items = db.relationship(
+        "KitchenMenuPlanItem",
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        order_by="KitchenMenuPlanItem.sort_order",
+    )
+    assignments = db.relationship(
+        "KitchenMenuAssignment",
+        back_populates="plan",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint("service_date", "meal_type", "name"),
+    )
+
+
+class KitchenMenuPlanItem(db.Model):
+    __tablename__ = "kitchen_menu_plan_item"
+
+    id = db.Column(db.Integer, primary_key=True)
+    plan_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_menu_plan.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    recipe_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_recipe.id"),
+        nullable=False,
+    )
+    sort_order = db.Column(db.Integer, nullable=False, default=0)
+
+    plan = db.relationship("KitchenMenuPlan", back_populates="items")
+    recipe = db.relationship("KitchenRecipe")
+
+    __table_args__ = (
+        db.UniqueConstraint("plan_id", "recipe_id"),
+    )
+
+
+class KitchenMenuAssignment(db.Model):
+    __tablename__ = "kitchen_menu_assignment"
+
+    id = db.Column(db.Integer, primary_key=True)
+    plan_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_menu_plan.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    school_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_school.id"),
+        nullable=False,
+    )
+    headcount = db.Column(db.Integer, nullable=False, default=0)
+
+    plan = db.relationship("KitchenMenuPlan", back_populates="assignments")
+    school = db.relationship("KitchenSchool")
+
+    __table_args__ = (
+        db.UniqueConstraint("plan_id", "school_id"),
     )

--- a/models.py
+++ b/models.py
@@ -28,7 +28,7 @@ class Checkin(db.Model):
 
 # ─────────────────────────────────────────────
 # 團膳正式模組
-# Recipe BOM（g / 人）→ 菜單 → 學校人數 → 採購單 snapshot
+# Recipe BOM（每人 AP 數量，可用 g 或 個）→ 菜單 → 學校人數 → 採購 snapshot
 # ─────────────────────────────────────────────
 
 
@@ -62,13 +62,13 @@ class KitchenIngredient(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
 
-    # 配方底層一律以 g 計算；採購則用 purchase_unit。
-    # 例：kg => 1000g；箱 => 18000g；斤 => 600g。
+    # 配方基本單位：大部分食材用 g；雞腿、蛋等可用 個。
+    base_unit = db.Column(db.String(10), nullable=False, default="g")
     purchase_unit = db.Column(db.String(20), nullable=False, default="kg")
+    # 欄位名稱沿用舊 schema；實際語意為「1 採購單位包含多少 base_unit」。
+    # base_unit=g：1 kg = 1000；base_unit=個：1 箱 = 50（個）。
     grams_per_purchase_unit = db.Column(db.Numeric(14, 3), nullable=False, default=1000)
-    # unit_price 是「每一個 purchase_unit」的價格。
     unit_price = db.Column(db.Numeric(14, 4), nullable=False, default=0)
-    # 建議叫貨量往上取整的最小增量。kg 可設 0.001；箱通常設 1。
     order_increment = db.Column(db.Numeric(14, 4), nullable=False, default=0.001)
 
     note = db.Column(db.String(255))
@@ -84,8 +84,8 @@ class KitchenRecipe(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False, unique=True)
-    category = db.Column(db.String(50))  # 主食 / 主菜 / 副菜 / 湯品 / 青菜...
-    # 成品預計每人打菜量（例如 95g）；不參與 AP 採購計算
+    category = db.Column(db.String(50))
+    # 成品預計每人打菜量（g）；不參與 AP 採購計算。
     serving_output_g = db.Column(db.Numeric(10, 2), nullable=True)
     note = db.Column(db.String(255))
     active = db.Column(db.Boolean, nullable=False, default=True)
@@ -114,7 +114,8 @@ class KitchenRecipeIngredient(db.Model):
         db.ForeignKey("kitchen_ingredient.id"),
         nullable=False,
     )
-    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g
+    # 欄位名稱沿用舊 schema；實際語意為「每人 AP 數量」，單位由 ingredient.base_unit 決定。
+    # 例：骨腿丁 88 g/人；棒棒腿 1 個/人。
     grams_per_person = db.Column(db.Numeric(12, 3), nullable=False)
 
     recipe = db.relationship("KitchenRecipe", back_populates="ingredients")
@@ -133,7 +134,7 @@ class KitchenMenuPlan(db.Model):
     meal_type = db.Column(db.String(30), nullable=False, default="午餐")
     name = db.Column(db.String(120), nullable=False, default="中央菜單")
     note = db.Column(db.String(255))
-    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed
+    status = db.Column(db.String(20), nullable=False, default="draft")
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -208,10 +209,11 @@ class KitchenPurchaseOrder(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     service_date = db.Column(db.Date, nullable=False, index=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
-    # 穩定 key 避免廠商改名後產生重複單；未指定供應商使用 "unassigned"。
+    # supplier_key 保留「系統原始分組來源」，人工換廠商不改 key，避免重新計算時產生重複草稿。
     supplier_key = db.Column(db.String(100), nullable=False)
     supplier_name_snapshot = db.Column(db.String(120), nullable=False)
-    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed / cancelled
+    supplier_overridden = db.Column(db.Boolean, nullable=False, default=False)
+    status = db.Column(db.String(20), nullable=False, default="draft")
     note = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -240,8 +242,9 @@ class KitchenPurchaseOrderItem(db.Model):
     )
     ingredient_id = db.Column(db.Integer, db.ForeignKey("kitchen_ingredient.id"), nullable=True)
 
-    # 下列欄位全部是 snapshot；正式單確認後不再從 master data 回算。
     ingredient_name_snapshot = db.Column(db.String(120), nullable=False)
+    base_unit_snapshot = db.Column(db.String(10), nullable=False, default="g")
+    # 欄位名稱 required_grams 沿用舊 schema；實際為 required base-unit amount。
     required_grams = db.Column(db.Numeric(16, 3), nullable=False, default=0)
     required_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     purchase_unit_snapshot = db.Column(db.String(20), nullable=False)
@@ -251,6 +254,8 @@ class KitchenPurchaseOrderItem(db.Model):
     unit_price_snapshot = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     amount = db.Column(db.Numeric(18, 4), nullable=False, default=0)
     note = db.Column(db.String(255))
+    # 使用者手動改過數量/單價/備註後，重新產生需求時保留人工值。
+    manual_override = db.Column(db.Boolean, nullable=False, default=False)
 
     order = db.relationship("KitchenPurchaseOrder", back_populates="items")
     ingredient = db.relationship("KitchenIngredient")

--- a/models.py
+++ b/models.py
@@ -28,7 +28,7 @@ class Checkin(db.Model):
 
 # ─────────────────────────────────────────────
 # 團膳正式模組
-# Recipe BOM（g / 人）→ 菜單 → 學校人數 → 採購單 snapshot
+# Recipe BOM（每人 AP 數量，可用 g 或 個）→ 菜單 → 學校人數 → 採購 snapshot
 # ─────────────────────────────────────────────
 
 
@@ -62,11 +62,13 @@ class KitchenIngredient(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
 
-    # 配方底層一律以 g 計算；採購則用 purchase_unit。
-    # 例：kg => 1000g；箱 => 18000g；斤 => 600g。
+    # 菜色配方的基本計量單位。大部分食材用 g；雞腿、蛋等可用 個。
+    base_unit = db.Column(db.String(10), nullable=False, default="g")
     purchase_unit = db.Column(db.String(20), nullable=False, default="kg")
+    # 歷史欄位名稱保留相容性；實際語意是「1 個採購單位含多少 base_unit」。
+    # base_unit=g：1 kg = 1000；base_unit=個：1 箱 = 50（個）等。
     grams_per_purchase_unit = db.Column(db.Numeric(14, 3), nullable=False, default=1000)
-    # unit_price 是「每一個 purchase_unit」的價格。
+    # unit_price 是每一個 purchase_unit 的價格。
     unit_price = db.Column(db.Numeric(14, 4), nullable=False, default=0)
     # 建議叫貨量往上取整的最小增量。kg 可設 0.001；箱通常設 1。
     order_increment = db.Column(db.Numeric(14, 4), nullable=False, default=0.001)
@@ -84,8 +86,8 @@ class KitchenRecipe(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False, unique=True)
-    category = db.Column(db.String(50))  # 主食 / 主菜 / 副菜 / 湯品 / 青菜...
-    # 成品預計每人打菜量（例如 95g）；不參與 AP 採購計算。
+    category = db.Column(db.String(50))
+    # 成品預計每人打菜量（g）；不參與 AP 採購計算。
     serving_output_g = db.Column(db.Numeric(10, 2), nullable=True)
     note = db.Column(db.String(255))
     active = db.Column(db.Boolean, nullable=False, default=True)
@@ -114,7 +116,8 @@ class KitchenRecipeIngredient(db.Model):
         db.ForeignKey("kitchen_ingredient.id"),
         nullable=False,
     )
-    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g。
+    # 歷史欄位名稱保留；實際語意是每人 AP 數量，單位看 ingredient.base_unit。
+    # 例：骨腿丁 88 g/人；棒棒腿 1 個/人。
     grams_per_person = db.Column(db.Numeric(12, 3), nullable=False)
 
     recipe = db.relationship("KitchenRecipe", back_populates="ingredients")
@@ -133,7 +136,7 @@ class KitchenMenuPlan(db.Model):
     meal_type = db.Column(db.String(30), nullable=False, default="午餐")
     name = db.Column(db.String(120), nullable=False, default="中央菜單")
     note = db.Column(db.String(255))
-    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed
+    status = db.Column(db.String(20), nullable=False, default="draft")
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -208,10 +211,11 @@ class KitchenPurchaseOrder(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     service_date = db.Column(db.Date, nullable=False, index=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
-    # 穩定 key 避免廠商改名後產生重複單；未指定供應商使用 "unassigned"。
+    # supplier_key 是自動分組來源 key；人工改廠商時保持不變，避免重算後找不到原草稿。
     supplier_key = db.Column(db.String(100), nullable=False)
     supplier_name_snapshot = db.Column(db.String(120), nullable=False)
-    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed / cancelled
+    supplier_overridden = db.Column(db.Boolean, nullable=False, default=False)
+    status = db.Column(db.String(20), nullable=False, default="draft")
     note = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -242,6 +246,8 @@ class KitchenPurchaseOrderItem(db.Model):
 
     # 下列欄位全部是 snapshot；正式單確認後不再從 master data 回算。
     ingredient_name_snapshot = db.Column(db.String(120), nullable=False)
+    base_unit_snapshot = db.Column(db.String(10), nullable=False, default="g")
+    # 歷史欄位名稱 required_grams 保留；實際是 required base-unit amount。
     required_grams = db.Column(db.Numeric(16, 3), nullable=False, default=0)
     required_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     purchase_unit_snapshot = db.Column(db.String(20), nullable=False)
@@ -251,6 +257,8 @@ class KitchenPurchaseOrderItem(db.Model):
     unit_price_snapshot = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     amount = db.Column(db.Numeric(18, 4), nullable=False, default=0)
     note = db.Column(db.String(255))
+    # 使用者手動改過數量/單價後，重新計算需求時保留人工值。
+    manual_override = db.Column(db.Boolean, nullable=False, default=False)
 
     order = db.relationship("KitchenPurchaseOrder", back_populates="items")
     ingredient = db.relationship("KitchenIngredient")

--- a/models.py
+++ b/models.py
@@ -28,7 +28,7 @@ class Checkin(db.Model):
 
 # ─────────────────────────────────────────────
 # 團膳正式模組
-# Recipe BOM（每人 AP 數量，可用 g 或 個）→ 菜單 → 學校人數 → 採購 snapshot
+# Recipe BOM（g / 人）→ 菜單 → 學校人數 → 採購單 snapshot
 # ─────────────────────────────────────────────
 
 
@@ -62,13 +62,11 @@ class KitchenIngredient(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
 
-    # 菜色配方的基本計量單位。大部分食材用 g；雞腿、蛋等可用 個。
-    base_unit = db.Column(db.String(10), nullable=False, default="g")
+    # 配方底層一律以 g 計算；採購則用 purchase_unit。
+    # 例：kg => 1000g；箱 => 18000g；斤 => 600g。
     purchase_unit = db.Column(db.String(20), nullable=False, default="kg")
-    # 歷史欄位名稱保留相容性；實際語意是「1 個採購單位含多少 base_unit」。
-    # base_unit=g：1 kg = 1000；base_unit=個：1 箱 = 50（個）等。
     grams_per_purchase_unit = db.Column(db.Numeric(14, 3), nullable=False, default=1000)
-    # unit_price 是每一個 purchase_unit 的價格。
+    # unit_price 是「每一個 purchase_unit」的價格。
     unit_price = db.Column(db.Numeric(14, 4), nullable=False, default=0)
     # 建議叫貨量往上取整的最小增量。kg 可設 0.001；箱通常設 1。
     order_increment = db.Column(db.Numeric(14, 4), nullable=False, default=0.001)
@@ -86,8 +84,8 @@ class KitchenRecipe(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False, unique=True)
-    category = db.Column(db.String(50))
-    # 成品預計每人打菜量（g）；不參與 AP 採購計算。
+    category = db.Column(db.String(50))  # 主食 / 主菜 / 副菜 / 湯品 / 青菜...
+    # 成品預計每人打菜量（例如 95g）；不參與 AP 採購計算
     serving_output_g = db.Column(db.Numeric(10, 2), nullable=True)
     note = db.Column(db.String(255))
     active = db.Column(db.Boolean, nullable=False, default=True)
@@ -116,8 +114,7 @@ class KitchenRecipeIngredient(db.Model):
         db.ForeignKey("kitchen_ingredient.id"),
         nullable=False,
     )
-    # 歷史欄位名稱保留；實際語意是每人 AP 數量，單位看 ingredient.base_unit。
-    # 例：骨腿丁 88 g/人；棒棒腿 1 個/人。
+    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g
     grams_per_person = db.Column(db.Numeric(12, 3), nullable=False)
 
     recipe = db.relationship("KitchenRecipe", back_populates="ingredients")
@@ -136,7 +133,7 @@ class KitchenMenuPlan(db.Model):
     meal_type = db.Column(db.String(30), nullable=False, default="午餐")
     name = db.Column(db.String(120), nullable=False, default="中央菜單")
     note = db.Column(db.String(255))
-    status = db.Column(db.String(20), nullable=False, default="draft")
+    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -211,11 +208,10 @@ class KitchenPurchaseOrder(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     service_date = db.Column(db.Date, nullable=False, index=True)
     supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
-    # supplier_key 是自動分組來源 key；人工改廠商時保持不變，避免重算後找不到原草稿。
+    # 穩定 key 避免廠商改名後產生重複單；未指定供應商使用 "unassigned"。
     supplier_key = db.Column(db.String(100), nullable=False)
     supplier_name_snapshot = db.Column(db.String(120), nullable=False)
-    supplier_overridden = db.Column(db.Boolean, nullable=False, default=False)
-    status = db.Column(db.String(20), nullable=False, default="draft")
+    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed / cancelled
     note = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -246,8 +242,6 @@ class KitchenPurchaseOrderItem(db.Model):
 
     # 下列欄位全部是 snapshot；正式單確認後不再從 master data 回算。
     ingredient_name_snapshot = db.Column(db.String(120), nullable=False)
-    base_unit_snapshot = db.Column(db.String(10), nullable=False, default="g")
-    # 歷史欄位名稱 required_grams 保留；實際是 required base-unit amount。
     required_grams = db.Column(db.Numeric(16, 3), nullable=False, default=0)
     required_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     purchase_unit_snapshot = db.Column(db.String(20), nullable=False)
@@ -257,8 +251,6 @@ class KitchenPurchaseOrderItem(db.Model):
     unit_price_snapshot = db.Column(db.Numeric(16, 4), nullable=False, default=0)
     amount = db.Column(db.Numeric(18, 4), nullable=False, default=0)
     note = db.Column(db.String(255))
-    # 使用者手動改過數量/單價後，重新計算需求時保留人工值。
-    manual_override = db.Column(db.Boolean, nullable=False, default=False)
 
     order = db.relationship("KitchenPurchaseOrder", back_populates="items")
     ingredient = db.relationship("KitchenIngredient")

--- a/models.py
+++ b/models.py
@@ -1,4 +1,6 @@
 # models.py
+from datetime import datetime
+
 from extensions import db
 
 
@@ -25,8 +27,8 @@ class Checkin(db.Model):
 
 
 # ─────────────────────────────────────────────
-# 團膳 / 萬能廚師替代模組
-# 中央菜單 → 分配學校與人數 → Recipe BOM → 採購彙總
+# 團膳正式模組
+# Recipe BOM（g / 人）→ 菜單 → 學校人數 → 採購單 snapshot
 # ─────────────────────────────────────────────
 
 
@@ -37,6 +39,8 @@ class KitchenSchool(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     code = db.Column(db.String(50), unique=True)
     active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
 class KitchenSupplier(db.Model):
@@ -46,6 +50,9 @@ class KitchenSupplier(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     phone = db.Column(db.String(50))
     note = db.Column(db.String(255))
+    active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
 class KitchenIngredient(db.Model):
@@ -53,14 +60,21 @@ class KitchenIngredient(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False, unique=True)
-    # 採購單價預設以每 kg 計價；每人配方固定以 g 儲存
-    unit_price = db.Column(db.Numeric(12, 4), nullable=False, default=0)
-    supplier_id = db.Column(
-        db.Integer,
-        db.ForeignKey("kitchen_supplier.id"),
-        nullable=True,
-    )
+    supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
+
+    # 配方底層一律以 g 計算；採購則用 purchase_unit。
+    # 例：kg => 1000g；箱 => 18000g；斤 => 600g。
+    purchase_unit = db.Column(db.String(20), nullable=False, default="kg")
+    grams_per_purchase_unit = db.Column(db.Numeric(14, 3), nullable=False, default=1000)
+    # unit_price 是「每一個 purchase_unit」的價格。
+    unit_price = db.Column(db.Numeric(14, 4), nullable=False, default=0)
+    # 建議叫貨量往上取整的最小增量。kg 可設 0.001；箱通常設 1。
+    order_increment = db.Column(db.Numeric(14, 4), nullable=False, default=0.001)
+
     note = db.Column(db.String(255))
+    active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     supplier = db.relationship("KitchenSupplier")
 
@@ -71,9 +85,12 @@ class KitchenRecipe(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False, unique=True)
     category = db.Column(db.String(50))  # 主食 / 主菜 / 副菜 / 湯品 / 青菜...
-    # 成品預計每人打菜量（例如 95g）；可空白，不參與採購計算
+    # 成品預計每人打菜量（例如 95g）；不參與 AP 採購計算。
     serving_output_g = db.Column(db.Numeric(10, 2), nullable=True)
     note = db.Column(db.String(255))
+    active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     ingredients = db.relationship(
         "KitchenRecipeIngredient",
@@ -97,14 +114,14 @@ class KitchenRecipeIngredient(db.Model):
         db.ForeignKey("kitchen_ingredient.id"),
         nullable=False,
     )
-    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g
-    grams_per_person = db.Column(db.Numeric(10, 3), nullable=False)
+    # AP 採購個人量：每人需要幾克，例如骨腿丁 88g。
+    grams_per_person = db.Column(db.Numeric(12, 3), nullable=False)
 
     recipe = db.relationship("KitchenRecipe", back_populates="ingredients")
     ingredient = db.relationship("KitchenIngredient")
 
     __table_args__ = (
-        db.UniqueConstraint("recipe_id", "ingredient_id"),
+        db.UniqueConstraint("recipe_id", "ingredient_id", name="uq_kitchen_recipe_ingredient"),
     )
 
 
@@ -114,8 +131,11 @@ class KitchenMenuPlan(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     service_date = db.Column(db.Date, nullable=False, index=True)
     meal_type = db.Column(db.String(30), nullable=False, default="午餐")
-    name = db.Column(db.String(120))
+    name = db.Column(db.String(120), nullable=False, default="中央菜單")
     note = db.Column(db.String(255))
+    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     items = db.relationship(
         "KitchenMenuPlanItem",
@@ -130,7 +150,7 @@ class KitchenMenuPlan(db.Model):
     )
 
     __table_args__ = (
-        db.UniqueConstraint("service_date", "meal_type", "name"),
+        db.UniqueConstraint("service_date", "meal_type", "name", name="uq_kitchen_menu_plan_identity"),
     )
 
 
@@ -154,7 +174,7 @@ class KitchenMenuPlanItem(db.Model):
     recipe = db.relationship("KitchenRecipe")
 
     __table_args__ = (
-        db.UniqueConstraint("plan_id", "recipe_id"),
+        db.UniqueConstraint("plan_id", "recipe_id", name="uq_kitchen_menu_plan_recipe"),
     )
 
 
@@ -178,5 +198,63 @@ class KitchenMenuAssignment(db.Model):
     school = db.relationship("KitchenSchool")
 
     __table_args__ = (
-        db.UniqueConstraint("plan_id", "school_id"),
+        db.UniqueConstraint("plan_id", "school_id", name="uq_kitchen_menu_assignment"),
+    )
+
+
+class KitchenPurchaseOrder(db.Model):
+    __tablename__ = "kitchen_purchase_order"
+
+    id = db.Column(db.Integer, primary_key=True)
+    service_date = db.Column(db.Date, nullable=False, index=True)
+    supplier_id = db.Column(db.Integer, db.ForeignKey("kitchen_supplier.id"), nullable=True)
+    # 穩定 key 避免廠商改名後產生重複單；未指定供應商使用 "unassigned"。
+    supplier_key = db.Column(db.String(100), nullable=False)
+    supplier_name_snapshot = db.Column(db.String(120), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="draft")  # draft / confirmed / cancelled
+    note = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    supplier = db.relationship("KitchenSupplier")
+    items = db.relationship(
+        "KitchenPurchaseOrderItem",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="KitchenPurchaseOrderItem.ingredient_name_snapshot",
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint("service_date", "supplier_key", name="uq_kitchen_purchase_order_supplier_day"),
+    )
+
+
+class KitchenPurchaseOrderItem(db.Model):
+    __tablename__ = "kitchen_purchase_order_item"
+
+    id = db.Column(db.Integer, primary_key=True)
+    order_id = db.Column(
+        db.Integer,
+        db.ForeignKey("kitchen_purchase_order.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    ingredient_id = db.Column(db.Integer, db.ForeignKey("kitchen_ingredient.id"), nullable=True)
+
+    # 下列欄位全部是 snapshot；正式單確認後不再從 master data 回算。
+    ingredient_name_snapshot = db.Column(db.String(120), nullable=False)
+    required_grams = db.Column(db.Numeric(16, 3), nullable=False, default=0)
+    required_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
+    purchase_unit_snapshot = db.Column(db.String(20), nullable=False)
+    grams_per_purchase_unit_snapshot = db.Column(db.Numeric(16, 3), nullable=False)
+    recommended_order_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
+    actual_order_qty = db.Column(db.Numeric(16, 4), nullable=False, default=0)
+    unit_price_snapshot = db.Column(db.Numeric(16, 4), nullable=False, default=0)
+    amount = db.Column(db.Numeric(18, 4), nullable=False, default=0)
+    note = db.Column(db.String(255))
+
+    order = db.relationship("KitchenPurchaseOrder", back_populates="items")
+    ingredient = db.relationship("KitchenIngredient")
+
+    __table_args__ = (
+        db.UniqueConstraint("order_id", "ingredient_id", name="uq_kitchen_purchase_order_item"),
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/scripts/bootstrap_kitchen_schema.py
+++ b/scripts/bootstrap_kitchen_schema.py
@@ -1,0 +1,76 @@
+"""Create the final kitchen_* schema without touching attendance tables.
+
+Use this only for an initial deployment where production has no kitchen tables yet.
+If any existing kitchen table is missing expected columns, this script refuses to alter it.
+That fail-closed behavior prevents accidental partial upgrades on production.
+"""
+
+from sqlalchemy import inspect
+
+from app import create_app
+from extensions import db
+
+
+KITCHEN_TABLES = (
+    "kitchen_school",
+    "kitchen_supplier",
+    "kitchen_ingredient",
+    "kitchen_recipe",
+    "kitchen_recipe_ingredient",
+    "kitchen_menu_plan",
+    "kitchen_menu_plan_item",
+    "kitchen_menu_assignment",
+    "kitchen_purchase_order",
+    "kitchen_purchase_order_item",
+)
+
+FORBIDDEN_TABLES = {"employee", "checkin", "employees", "checkins"}
+
+
+def main():
+    app = create_app({"AUTO_CREATE_DB": False})
+    with app.app_context():
+        engine = db.engine
+        inspector = inspect(engine)
+        existing = set(inspector.get_table_names())
+
+        # This script must never mutate attendance tables.
+        assert not (set(KITCHEN_TABLES) & FORBIDDEN_TABLES)
+
+        mismatches = []
+        for name in KITCHEN_TABLES:
+            if name not in existing:
+                continue
+            actual_columns = {column["name"] for column in inspector.get_columns(name)}
+            expected_columns = set(db.metadata.tables[name].columns.keys())
+            missing = sorted(expected_columns - actual_columns)
+            if missing:
+                mismatches.append((name, missing))
+
+        if mismatches:
+            print("REFUSING TO ALTER EXISTING KITCHEN TABLES.")
+            for table, missing in mismatches:
+                print(f"- {table}: missing columns {', '.join(missing)}")
+            print("Use the reviewed kitchen migration on a staging clone first.")
+            raise SystemExit(2)
+
+        created = []
+        for name in KITCHEN_TABLES:
+            if name in existing:
+                continue
+            table = db.metadata.tables[name]
+            table.create(bind=engine, checkfirst=True)
+            created.append(name)
+
+        if created:
+            print("Created kitchen tables:")
+            for name in created:
+                print(f"- {name}")
+        else:
+            print("Kitchen schema already matches the expected columns; nothing created.")
+
+        print("Attendance tables were not altered.")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/kitchen_mobile.css
+++ b/static/kitchen_mobile.css
@@ -1,0 +1,293 @@
+/* Mobile-first enhancement for /admin/order-tool only.
+   Loaded by app.py only on kitchen pages, so attendance UI is untouched. */
+
+:root {
+  --k-mobile-bg: #f4f6f8;
+  --k-mobile-card: #ffffff;
+  --k-mobile-text: #17202a;
+  --k-mobile-muted: #667085;
+  --k-mobile-line: #e5e7eb;
+  --k-mobile-brand: #1769aa;
+  --k-mobile-brand-soft: #eaf3fb;
+  --k-mobile-danger: #b42318;
+}
+
+html { -webkit-text-size-adjust: 100%; }
+body { min-height: 100dvh; }
+
+/* Better touch targets on every screen size. */
+input,
+select,
+textarea,
+.btn,
+.nav a {
+  min-height: 44px;
+}
+
+input,
+select,
+textarea {
+  font-size: 16px; /* prevents iOS Safari auto zoom */
+}
+
+.btn {
+  font-weight: 650;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.card {
+  overflow: hidden;
+}
+
+table {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Visual cue for horizontally scrollable tables. */
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+.table-scroll > table {
+  min-width: 620px;
+}
+
+.nav a.active {
+  background: var(--k-mobile-brand-soft);
+  color: var(--k-mobile-brand);
+  font-weight: 750;
+}
+
+@media (max-width: 800px) {
+  body {
+    background: var(--k-mobile-bg);
+    padding-bottom: calc(76px + env(safe-area-inset-bottom));
+  }
+
+  .wrap {
+    width: 100%;
+    max-width: none;
+    padding: 12px;
+  }
+
+  /* The first header becomes the mobile app bar. */
+  .wrap > .top.no-print {
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    margin: -12px -12px 14px;
+    padding: calc(10px + env(safe-area-inset-top)) 16px 10px;
+    min-height: 58px;
+    background: rgba(255,255,255,.96);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border-bottom: 1px solid var(--k-mobile-line);
+    box-shadow: 0 1px 8px rgba(16,24,40,.05);
+  }
+
+  .wrap > .top.no-print > h1 {
+    font-size: 20px;
+    line-height: 1.2;
+    letter-spacing: -.01em;
+  }
+
+  /* Existing navigation becomes a thumb-friendly bottom bar. */
+  .wrap > .top.no-print > .nav {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 2px;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+    background: rgba(255,255,255,.98);
+    border-top: 1px solid var(--k-mobile-line);
+    box-shadow: 0 -4px 16px rgba(16,24,40,.08);
+  }
+
+  .wrap > .top.no-print > .nav::-webkit-scrollbar { display: none; }
+
+  .wrap > .top.no-print > .nav a {
+    flex: 0 0 68px;
+    min-width: 68px;
+    min-height: 54px;
+    padding: 7px 5px;
+    border-radius: 12px;
+    background: transparent;
+    color: #475467;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.15;
+    text-align: center;
+    white-space: normal;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .wrap > .top.no-print > .nav a.active {
+    background: var(--k-mobile-brand-soft);
+    color: var(--k-mobile-brand);
+  }
+
+  h1 { font-size: 22px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
+
+  .grid {
+    gap: 12px;
+  }
+
+  .span-4,
+  .span-5,
+  .span-6,
+  .span-7,
+  .span-8,
+  .span-12 {
+    grid-column: span 12;
+  }
+
+  .card {
+    border-radius: 14px;
+    padding: 15px;
+    box-shadow: 0 1px 4px rgba(16,24,40,.04);
+  }
+
+  /* Dashboard statistics stay compact on phones. */
+  .grid > .card.span-4 {
+    grid-column: span 4;
+    padding: 12px 8px;
+    text-align: center;
+  }
+  .grid > .card.span-4 .stat {
+    font-size: 26px;
+  }
+  .grid > .card.span-4 .muted {
+    font-size: 11px;
+  }
+
+  /* Forms become one-control-per-row and easy to use with one thumb. */
+  .row {
+    width: 100%;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .field {
+    flex: 1 1 100%;
+    width: 100%;
+    min-width: 0;
+  }
+
+  label {
+    font-size: 13px;
+    margin-bottom: 2px;
+  }
+
+  input,
+  select,
+  textarea {
+    min-height: 48px;
+    padding: 11px 12px;
+    border-radius: 11px;
+  }
+
+  .card > form > .btn,
+  .card > form > button.btn,
+  .row > .btn,
+  .row > button.btn {
+    width: 100%;
+    min-height: 48px;
+    border-radius: 12px;
+  }
+
+  /* Do not stretch destructive buttons inside data rows. */
+  form.inline .btn {
+    min-width: 68px;
+    min-height: 40px;
+    padding: 7px 10px;
+  }
+
+  /* Existing tables were display:block; wrapper handles scrolling instead. */
+  table {
+    display: table;
+    width: 100%;
+    white-space: nowrap;
+  }
+
+  th,
+  td {
+    padding: 11px 10px;
+    font-size: 13px;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .table-scroll {
+    margin: 0 -15px;
+    width: calc(100% + 30px);
+    padding: 0 15px 5px;
+  }
+
+  .table-scroll::after {
+    content: "左右滑動查看更多";
+    display: block;
+    width: max-content;
+    margin: 7px 0 0 auto;
+    color: var(--k-mobile-muted);
+    font-size: 11px;
+  }
+
+  .pill {
+    font-size: 11px;
+  }
+
+  .notice {
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  /* Secondary page headings should not compete with the app bar. */
+  .wrap > .top:not(.no-print) {
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .wrap > .top:not(.no-print) > .btn,
+  .wrap > .top:not(.no-print) > a.btn {
+    width: 100%;
+  }
+
+  /* Purchase output: quantity is the key field on a phone. */
+  .purchase-group td:nth-child(2) {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 430px) {
+  .wrap { padding: 10px; }
+  .wrap > .top.no-print { margin-left: -10px; margin-right: -10px; }
+  .card { padding: 13px; }
+  .grid { gap: 10px; }
+  .table-scroll { margin-left: -13px; width: calc(100% + 26px); padding-left: 13px; padding-right: 13px; }
+}
+
+@media print {
+  body { padding-bottom: 0 !important; }
+  .table-scroll { overflow: visible; }
+  .table-scroll > table { min-width: 0; }
+  .table-scroll::after { display: none; }
+}

--- a/static/kitchen_mobile.css
+++ b/static/kitchen_mobile.css
@@ -1,293 +1,68 @@
-/* Mobile-first enhancement for /admin/order-tool only.
-   Loaded by app.py only on kitchen pages, so attendance UI is untouched. */
-
 :root {
-  --k-mobile-bg: #f4f6f8;
-  --k-mobile-card: #ffffff;
-  --k-mobile-text: #17202a;
-  --k-mobile-muted: #667085;
-  --k-mobile-line: #e5e7eb;
-  --k-mobile-brand: #1769aa;
-  --k-mobile-brand-soft: #eaf3fb;
-  --k-mobile-danger: #b42318;
+  --bg:#f4f6f8; --card:#fff; --text:#17202a; --muted:#667085; --line:#e5e7eb;
+  --brand:#1769aa; --brand-dark:#0f5b91; --brand-soft:#eaf3fb;
+  --danger:#b42318; --danger-soft:#fff0ee; --ok:#157347; --ok-soft:#ecfdf3;
+  --warn:#9a6700; --warn-soft:#fff8e6;
 }
-
-html { -webkit-text-size-adjust: 100%; }
-body { min-height: 100dvh; }
-
-/* Better touch targets on every screen size. */
-input,
-select,
-textarea,
-.btn,
-.nav a {
-  min-height: 44px;
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{margin:0;min-height:100dvh;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans TC","Microsoft JhengHei",sans-serif}
+a{color:var(--brand);text-decoration:none}
+a:hover{text-decoration:underline}
+.wrap{max-width:1220px;margin:auto;padding:24px}
+.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px;flex-wrap:wrap}
+.top h1{margin:0;font-size:26px}
+.nav{display:flex;gap:7px;flex-wrap:wrap;align-items:center}
+.nav a{display:inline-flex;align-items:center;justify-content:center;min-height:42px;padding:9px 13px;border-radius:10px;background:var(--brand);color:#fff;font-size:14px;font-weight:650;text-decoration:none}
+.nav a:hover{background:var(--brand-dark)}
+.nav a.active{background:var(--brand-soft);color:var(--brand)}
+.nav .logout{background:#eef2f6;color:#344054}
+.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}
+.span-3{grid-column:span 3}.span-4{grid-column:span 4}.span-5{grid-column:span 5}.span-6{grid-column:span 6}.span-7{grid-column:span 7}.span-8{grid-column:span 8}.span-9{grid-column:span 9}.span-12{grid-column:span 12}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px;box-shadow:0 2px 8px rgba(16,24,40,.04);overflow:hidden}
+h1,h2,h3{line-height:1.25}h2{font-size:20px;margin:0 0 14px}h3{font-size:16px;margin:0 0 10px}
+.muted{color:var(--muted);font-size:13px}.stat{font-size:30px;font-weight:800}.right{text-align:right}.center{text-align:center}
+.row{display:flex;gap:10px;align-items:end;flex-wrap:wrap}.row.center-y{align-items:center}.row.between{justify-content:space-between}
+.field{display:flex;flex-direction:column;gap:5px;min-width:150px;flex:1}
+label{font-size:13px;color:#475467;font-weight:650}
+input,select,textarea{width:100%;min-height:44px;padding:9px 10px;border:1px solid #cfd6df;border-radius:9px;background:#fff;color:var(--text);font:inherit}
+textarea{min-height:88px;resize:vertical}
+input:focus,select:focus,textarea:focus{outline:2px solid #b7d8f0;border-color:var(--brand)}
+.btn,button.btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;min-height:42px;border:0;border-radius:10px;padding:9px 14px;background:var(--brand);color:#fff;cursor:pointer;font:inherit;font-size:14px;font-weight:700;text-decoration:none}
+.btn:hover,button.btn:hover{background:var(--brand-dark);text-decoration:none}.btn.secondary{background:#eef3f8;color:#24445f}.btn.danger{background:var(--danger-soft);color:var(--danger)}.btn.ok{background:var(--ok);color:#fff}.btn.warn{background:var(--warn-soft);color:var(--warn)}
+.inline{display:inline}.actions{display:flex;gap:7px;flex-wrap:wrap;align-items:center}.actions form{margin:0}
+hr{border:0;border-top:1px solid var(--line);margin:18px 0}
+table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}th,td{padding:10px 8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:middle;font-size:14px}th{font-size:12px;color:#667085;background:#fafbfc}tr:last-child td{border-bottom:0}
+.table-scroll{width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:thin}.table-scroll>table{min-width:650px}
+.pill{display:inline-block;background:var(--brand-soft);color:#175c91;border-radius:999px;padding:3px 8px;font-size:12px;font-weight:650}.pill.ok{background:var(--ok-soft);color:var(--ok)}.pill.warn{background:var(--warn-soft);color:var(--warn)}.pill.off{background:#f2f4f7;color:#667085}
+.empty{padding:28px;text-align:center;color:var(--muted)}
+.flash{padding:11px 14px;border-radius:10px;margin:0 0 14px;border:1px solid transparent;font-size:14px}.flash.success{background:var(--ok-soft);color:#067647;border-color:#abefc6}.flash.error{background:#fef3f2;color:var(--danger);border-color:#fecdca}.flash.warning{background:var(--warn-soft);color:#7a4b00;border-color:#fde3a7}.notice{padding:10px 12px;border-radius:10px;background:var(--warn-soft);color:#7a4b00;margin-bottom:14px}
+.kpi{display:flex;flex-direction:column;gap:3px}.kpi .stat{font-size:28px}
+.week-grid{display:grid;grid-template-columns:repeat(7,minmax(150px,1fr));gap:10px;overflow-x:auto;padding-bottom:5px}.day-card{min-width:150px;border:1px solid var(--line);border-radius:12px;padding:12px;background:#fff}.day-card .date{font-weight:800;margin-bottom:7px}.dish{padding:5px 0;border-bottom:1px dashed #e7eaee;font-size:13px}.dish:last-child{border-bottom:0}
+.purchase-total{font-size:22px;font-weight:800}.locked{opacity:.72}.print-title{display:none}
+@media(max-width:900px){.span-3,.span-4,.span-5,.span-6,.span-7,.span-8,.span-9{grid-column:span 12}.week-grid{grid-template-columns:repeat(7,180px)}}
+@media(max-width:800px){
+  body{padding-bottom:calc(76px + env(safe-area-inset-bottom))}
+  .wrap{width:100%;max-width:none;padding:12px}
+  .wrap>.top.no-print{position:sticky;top:0;z-index:900;margin:-12px -12px 14px;padding:calc(10px + env(safe-area-inset-top)) 16px 10px;min-height:58px;background:rgba(255,255,255,.97);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);border-bottom:1px solid var(--line);box-shadow:0 1px 8px rgba(16,24,40,.05)}
+  .wrap>.top.no-print>h1{font-size:20px}
+  .wrap>.top.no-print>.nav{position:fixed;z-index:1000;left:0;right:0;bottom:0;display:flex;flex-wrap:nowrap;gap:2px;overflow-x:auto;padding:6px 8px calc(6px + env(safe-area-inset-bottom));background:rgba(255,255,255,.98);border-top:1px solid var(--line);box-shadow:0 -4px 16px rgba(16,24,40,.08)}
+  .wrap>.top.no-print>.nav::-webkit-scrollbar{display:none}
+  .wrap>.top.no-print>.nav a{flex:0 0 68px;min-width:68px;min-height:54px;padding:7px 5px;border-radius:12px;background:transparent;color:#475467;font-size:12px;line-height:1.15;text-align:center;white-space:normal}
+  .wrap>.top.no-print>.nav a.active{background:var(--brand-soft);color:var(--brand)}
+  .wrap>.top.no-print>.nav .logout{display:none}
+  .grid{gap:12px}.card{padding:15px}
+  .dashboard-kpis{grid-template-columns:repeat(3,1fr)}.dashboard-kpis>.card{grid-column:span 1;padding:12px 7px;text-align:center}.dashboard-kpis .stat{font-size:24px}.dashboard-kpis .muted{font-size:11px}
+  input,select,textarea{font-size:16px;min-height:48px;padding:11px 12px;border-radius:11px}
+  .field{flex:1 1 100%;min-width:0;width:100%}.row{width:100%;align-items:stretch}
+  .stack-mobile>.btn,.stack-mobile>button,.stack-mobile>form{width:100%}.stack-mobile>form .btn{width:100%}
+  form.main-form>.btn,form.main-form>button.btn{width:100%;min-height:48px}
+  form.inline .btn{min-width:64px;min-height:40px;padding:7px 9px}
+  .table-scroll{margin:0 -15px;width:calc(100% + 30px);padding:0 15px 5px}.table-scroll::after{content:"左右滑動查看更多";display:block;width:max-content;margin:7px 0 0 auto;color:var(--muted);font-size:11px}
+  th,td{padding:11px 9px;font-size:13px}.top:not(.no-print){align-items:flex-start}.top:not(.no-print)>.btn{width:100%}
+  .week-grid{grid-template-columns:repeat(7,165px);margin:0 -15px;padding:0 15px 7px;width:calc(100% + 30px)}
 }
-
-input,
-select,
-textarea {
-  font-size: 16px; /* prevents iOS Safari auto zoom */
-}
-
-.btn {
-  font-weight: 650;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-}
-
-.card {
-  overflow: hidden;
-}
-
-table {
-  font-variant-numeric: tabular-nums;
-}
-
-/* Visual cue for horizontally scrollable tables. */
-.table-scroll {
-  width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-}
-.table-scroll > table {
-  min-width: 620px;
-}
-
-.nav a.active {
-  background: var(--k-mobile-brand-soft);
-  color: var(--k-mobile-brand);
-  font-weight: 750;
-}
-
-@media (max-width: 800px) {
-  body {
-    background: var(--k-mobile-bg);
-    padding-bottom: calc(76px + env(safe-area-inset-bottom));
-  }
-
-  .wrap {
-    width: 100%;
-    max-width: none;
-    padding: 12px;
-  }
-
-  /* The first header becomes the mobile app bar. */
-  .wrap > .top.no-print {
-    position: sticky;
-    top: 0;
-    z-index: 900;
-    margin: -12px -12px 14px;
-    padding: calc(10px + env(safe-area-inset-top)) 16px 10px;
-    min-height: 58px;
-    background: rgba(255,255,255,.96);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-    border-bottom: 1px solid var(--k-mobile-line);
-    box-shadow: 0 1px 8px rgba(16,24,40,.05);
-  }
-
-  .wrap > .top.no-print > h1 {
-    font-size: 20px;
-    line-height: 1.2;
-    letter-spacing: -.01em;
-  }
-
-  /* Existing navigation becomes a thumb-friendly bottom bar. */
-  .wrap > .top.no-print > .nav {
-    position: fixed;
-    z-index: 1000;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    flex-wrap: nowrap;
-    gap: 2px;
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
-    -webkit-overflow-scrolling: touch;
-    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
-    background: rgba(255,255,255,.98);
-    border-top: 1px solid var(--k-mobile-line);
-    box-shadow: 0 -4px 16px rgba(16,24,40,.08);
-  }
-
-  .wrap > .top.no-print > .nav::-webkit-scrollbar { display: none; }
-
-  .wrap > .top.no-print > .nav a {
-    flex: 0 0 68px;
-    min-width: 68px;
-    min-height: 54px;
-    padding: 7px 5px;
-    border-radius: 12px;
-    background: transparent;
-    color: #475467;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1.15;
-    text-align: center;
-    white-space: normal;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .wrap > .top.no-print > .nav a.active {
-    background: var(--k-mobile-brand-soft);
-    color: var(--k-mobile-brand);
-  }
-
-  h1 { font-size: 22px; }
-  h2 { font-size: 18px; }
-  h3 { font-size: 16px; }
-
-  .grid {
-    gap: 12px;
-  }
-
-  .span-4,
-  .span-5,
-  .span-6,
-  .span-7,
-  .span-8,
-  .span-12 {
-    grid-column: span 12;
-  }
-
-  .card {
-    border-radius: 14px;
-    padding: 15px;
-    box-shadow: 0 1px 4px rgba(16,24,40,.04);
-  }
-
-  /* Dashboard statistics stay compact on phones. */
-  .grid > .card.span-4 {
-    grid-column: span 4;
-    padding: 12px 8px;
-    text-align: center;
-  }
-  .grid > .card.span-4 .stat {
-    font-size: 26px;
-  }
-  .grid > .card.span-4 .muted {
-    font-size: 11px;
-  }
-
-  /* Forms become one-control-per-row and easy to use with one thumb. */
-  .row {
-    width: 100%;
-    align-items: stretch;
-    gap: 10px;
-  }
-
-  .field {
-    flex: 1 1 100%;
-    width: 100%;
-    min-width: 0;
-  }
-
-  label {
-    font-size: 13px;
-    margin-bottom: 2px;
-  }
-
-  input,
-  select,
-  textarea {
-    min-height: 48px;
-    padding: 11px 12px;
-    border-radius: 11px;
-  }
-
-  .card > form > .btn,
-  .card > form > button.btn,
-  .row > .btn,
-  .row > button.btn {
-    width: 100%;
-    min-height: 48px;
-    border-radius: 12px;
-  }
-
-  /* Do not stretch destructive buttons inside data rows. */
-  form.inline .btn {
-    min-width: 68px;
-    min-height: 40px;
-    padding: 7px 10px;
-  }
-
-  /* Existing tables were display:block; wrapper handles scrolling instead. */
-  table {
-    display: table;
-    width: 100%;
-    white-space: nowrap;
-  }
-
-  th,
-  td {
-    padding: 11px 10px;
-    font-size: 13px;
-  }
-
-  th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-  }
-
-  .table-scroll {
-    margin: 0 -15px;
-    width: calc(100% + 30px);
-    padding: 0 15px 5px;
-  }
-
-  .table-scroll::after {
-    content: "左右滑動查看更多";
-    display: block;
-    width: max-content;
-    margin: 7px 0 0 auto;
-    color: var(--k-mobile-muted);
-    font-size: 11px;
-  }
-
-  .pill {
-    font-size: 11px;
-  }
-
-  .notice {
-    font-size: 13px;
-    line-height: 1.5;
-  }
-
-  /* Secondary page headings should not compete with the app bar. */
-  .wrap > .top:not(.no-print) {
-    align-items: flex-start;
-    gap: 10px;
-  }
-  .wrap > .top:not(.no-print) > .btn,
-  .wrap > .top:not(.no-print) > a.btn {
-    width: 100%;
-  }
-
-  /* Purchase output: quantity is the key field on a phone. */
-  .purchase-group td:nth-child(2) {
-    font-size: 14px;
-  }
-}
-
-@media (max-width: 430px) {
-  .wrap { padding: 10px; }
-  .wrap > .top.no-print { margin-left: -10px; margin-right: -10px; }
-  .card { padding: 13px; }
-  .grid { gap: 10px; }
-  .table-scroll { margin-left: -13px; width: calc(100% + 26px); padding-left: 13px; padding-right: 13px; }
-}
-
-@media print {
-  body { padding-bottom: 0 !important; }
-  .table-scroll { overflow: visible; }
-  .table-scroll > table { min-width: 0; }
-  .table-scroll::after { display: none; }
+@media(max-width:430px){.wrap{padding:10px}.wrap>.top.no-print{margin-left:-10px;margin-right:-10px}.card{padding:13px}.table-scroll{margin-left:-13px;width:calc(100% + 26px);padding-left:13px;padding-right:13px}.dashboard-kpis .stat{font-size:22px}}
+@media print{
+  body{background:#fff;padding:0!important}.no-print{display:none!important}.wrap{max-width:none;padding:0}.card{box-shadow:none;border:0;padding:0;overflow:visible}.table-scroll{overflow:visible;margin:0;width:100%;padding:0}.table-scroll>table{min-width:0}.table-scroll::after{display:none!important}table{display:table;white-space:normal}th,td{font-size:10.5px;padding:5px}.purchase-group{break-inside:avoid;margin-bottom:20px}.print-title{display:block;margin-bottom:16px}h1{font-size:20px}h2{font-size:16px}.flash{display:none}
 }

--- a/static/kitchen_ui.js
+++ b/static/kitchen_ui.js
@@ -1,0 +1,38 @@
+(() => {
+  const path = window.location.pathname.replace(/\/$/, "");
+
+  // Highlight the current kitchen section in both desktop and mobile nav.
+  const navLinks = document.querySelectorAll('.wrap > .top.no-print > .nav a');
+  let best = null;
+  let bestLength = -1;
+
+  navLinks.forEach((link) => {
+    try {
+      const linkPath = new URL(link.href, window.location.origin).pathname.replace(/\/$/, "");
+      const matches = path === linkPath || (linkPath !== '/admin/order-tool' && path.startsWith(linkPath + '/'));
+      if (matches && linkPath.length > bestLength) {
+        best = link;
+        bestLength = linkPath.length;
+      }
+    } catch (_) {
+      // Ignore malformed links; all generated url_for links should be valid.
+    }
+  });
+
+  if (!best && path === '/admin/order-tool') {
+    best = navLinks[0] || null;
+  }
+  if (best) {
+    best.classList.add('active');
+    best.setAttribute('aria-current', 'page');
+  }
+
+  // Wrap data tables so wide desktop tables remain usable on phones.
+  document.querySelectorAll('.card > table').forEach((table) => {
+    if (table.parentElement?.classList.contains('table-scroll')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'table-scroll';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  });
+})();

--- a/static/kitchen_ui.js
+++ b/static/kitchen_ui.js
@@ -1,7 +1,6 @@
 (() => {
   const path = window.location.pathname.replace(/\/$/, "");
 
-  // Highlight the current kitchen section in both desktop and mobile nav.
   const navLinks = document.querySelectorAll('.wrap > .top.no-print > .nav a');
   let best = null;
   let bestLength = -1;
@@ -15,19 +14,28 @@
         bestLength = linkPath.length;
       }
     } catch (_) {
-      // Ignore malformed links; all generated url_for links should be valid.
+      // Generated url_for links should be valid; ignore anything malformed.
     }
   });
 
   if (!best && path === '/admin/order-tool') {
     best = navLinks[0] || null;
   }
+
   if (best) {
     best.classList.add('active');
     best.setAttribute('aria-current', 'page');
+
+    // On phones the bottom navigation is horizontally scrollable. Keep the
+    // current section visible after each page load instead of leaving the
+    // user looking at the left-most tabs.
+    if (window.matchMedia('(max-width: 800px)').matches) {
+      requestAnimationFrame(() => {
+        best.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'center' });
+      });
+    }
   }
 
-  // Wrap data tables so wide desktop tables remain usable on phones.
   document.querySelectorAll('.card > table').forEach((table) => {
     if (table.parentElement?.classList.contains('table-scroll')) return;
     const wrapper = document.createElement('div');

--- a/templates/kitchen/base.html
+++ b/templates/kitchen/base.html
@@ -12,6 +12,7 @@
 <main class="wrap">
   <div class="top no-print">
     <h1>團膳管理</h1>
+    <a class="btn secondary" href="{{ url_for('auth.logout') }}">登出</a>
     <nav class="nav" aria-label="團膳管理主選單">
       <a href="{{ url_for('order_tool.index') }}">總覽</a>
       <a href="{{ url_for('order_tool.plans') }}">菜單</a>
@@ -20,7 +21,6 @@
       <a href="{{ url_for('order_tool.schools') }}">學校</a>
       <a href="{{ url_for('order_tool.suppliers') }}">廠商</a>
       <a href="{{ url_for('order_tool.purchases') }}">採購叫貨</a>
-      <a class="logout" href="{{ url_for('auth.logout') }}">登出</a>
     </nav>
   </div>
 
@@ -32,7 +32,7 @@
 
   {% block content %}{% endblock %}
 </main>
-<script src="{{ url_for('static', filename='kitchen_ui.js') }}?v=2" defer></script>
+<script src="{{ url_for('static', filename='kitchen_ui.js') }}?v=3" defer></script>
 {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/kitchen/base.html
+++ b/templates/kitchen/base.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light">
+  <title>{% block title %}團膳管理{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='kitchen_mobile.css') }}?v=4">
+  {% block head %}{% endblock %}
+</head>
+<body>
+<main class="wrap">
+  <div class="top no-print">
+    <h1>團膳管理</h1>
+    <nav class="nav" aria-label="團膳管理主選單">
+      <a href="{{ url_for('order_tool.index') }}">總覽</a>
+      <a href="{{ url_for('order_tool.plans') }}">菜單</a>
+      <a href="{{ url_for('order_tool.recipes') }}">菜色配方</a>
+      <a href="{{ url_for('order_tool.ingredients') }}">食材</a>
+      <a href="{{ url_for('order_tool.schools') }}">學校</a>
+      <a href="{{ url_for('order_tool.suppliers') }}">廠商</a>
+      <a href="{{ url_for('order_tool.purchases') }}">採購叫貨</a>
+      <a class="logout" href="{{ url_for('auth.logout') }}">登出</a>
+    </nav>
+  </div>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      <div class="flash {{ category }}" role="status">{{ message }}</div>
+    {% endfor %}
+  {% endwith %}
+
+  {% block content %}{% endblock %}
+</main>
+<script src="{{ url_for('static', filename='kitchen_ui.js') }}?v=2" defer></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/kitchen/dashboard.html
+++ b/templates/kitchen/dashboard.html
@@ -6,6 +6,21 @@
   <section class="card span-4"><div class="kpi"><div class="muted">啟用食材</div><div class="stat">{{ ingredient_count }}</div></div></section>
   <section class="card span-4"><div class="kpi"><div class="muted">供餐學校</div><div class="stat">{{ school_count }}</div></div></section>
 
+  {% if recipe_count == 0 or ingredient_count == 0 or school_count == 0 %}
+  <section class="card span-12 onboarding">
+    <h2>第一次使用？照這個順序就好</h2>
+    <div class="muted">不用一次把所有資料建完。先用一間學校、一個廠商、一個食材、一個菜色跑通即可。</div>
+    <div class="onboarding-steps">
+      <a class="onboarding-step {{ 'done' if school_count else '' }}" href="{{ url_for('order_tool.schools') }}"><b>1. 學校</b><span>{{ '已有資料 ✓' if school_count else '先建立供餐學校' }}</span></a>
+      <a class="onboarding-step" href="{{ url_for('order_tool.suppliers') }}"><b>2. 廠商</b><span>建立叫貨供應商</span></a>
+      <a class="onboarding-step {{ 'done' if ingredient_count else '' }}" href="{{ url_for('order_tool.ingredients') }}"><b>3. 食材</b><span>{{ '已有資料 ✓' if ingredient_count else '設定食材、單價、規格' }}</span></a>
+      <a class="onboarding-step {{ 'done' if recipe_count else '' }}" href="{{ url_for('order_tool.recipes') }}"><b>4. 菜色配方</b><span>{{ '已有資料 ✓' if recipe_count else '建立菜色與每人 AP 用量' }}</span></a>
+      <a class="onboarding-step" href="{{ url_for('order_tool.plans') }}"><b>5. 菜單</b><span>排菜並輸入各校人數</span></a>
+      <a class="onboarding-step" href="{{ url_for('order_tool.purchases') }}"><b>6. 採購</b><span>產生草稿、確認後再叫貨</span></a>
+    </div>
+  </section>
+  {% endif %}
+
   <section class="card span-12">
     <div class="top">
       <div><h2>未來 7 天菜單</h2><div class="muted">中央菜單可同時指派多間學校與各自人數。</div></div>

--- a/templates/kitchen/dashboard.html
+++ b/templates/kitchen/dashboard.html
@@ -1,0 +1,35 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}團膳管理{% endblock %}
+{% block content %}
+<div class="grid dashboard-kpis">
+  <section class="card span-4"><div class="kpi"><div class="muted">啟用菜色</div><div class="stat">{{ recipe_count }}</div></div></section>
+  <section class="card span-4"><div class="kpi"><div class="muted">啟用食材</div><div class="stat">{{ ingredient_count }}</div></div></section>
+  <section class="card span-4"><div class="kpi"><div class="muted">供餐學校</div><div class="stat">{{ school_count }}</div></div></section>
+
+  <section class="card span-12">
+    <div class="top">
+      <div><h2>未來 7 天菜單</h2><div class="muted">中央菜單可同時指派多間學校與各自人數。</div></div>
+      <a class="btn" href="{{ url_for('order_tool.plans') }}">新增 / 編輯菜單</a>
+    </div>
+    {% if plans %}
+    <div class="table-scroll"><table>
+      <thead><tr><th>日期</th><th>餐別</th><th>菜單</th><th>菜色</th><th>學校 / 人數</th><th>狀態</th><th></th></tr></thead>
+      <tbody>{% for p in plans %}<tr>
+        <td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name }}</td>
+        <td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td>
+        <td><span class="pill {{ 'ok' if p.status == 'confirmed' else 'warn' }}">{{ '已確認' if p.status == 'confirmed' else '草稿' }}</span></td>
+        <td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">開啟</a></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>
+    {% else %}<div class="empty">這 7 天還沒有菜單。</div>{% endif %}
+  </section>
+
+  <section class="card span-12">
+    <div class="top"><div><h2>最近採購單</h2><div class="muted">正式保存的叫貨紀錄，不會因主檔日後修改而改變。</div></div><a class="btn secondary" href="{{ url_for('order_tool.purchases') }}">採購歷史</a></div>
+    {% if recent_orders %}<div class="table-scroll"><table>
+      <thead><tr><th>日期</th><th>廠商</th><th>狀態</th><th class="right">金額</th><th></th></tr></thead>
+      <tbody>{% for o in recent_orders %}<tr><td>{{ o.service_date }}</td><td>{{ o.supplier_name_snapshot }}</td><td><span class="pill {{ 'ok' if o.status == 'confirmed' else ('off' if o.status == 'cancelled' else 'warn') }}">{{ status_label(o.status) }}</span></td><td class="right">${{ '%.2f'|format(order_total(o)|float) }}</td><td><a href="{{ url_for('order_tool.purchase_detail', order_id=o.id) }}">開啟</a></td></tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">尚未建立採購單。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/ingredients.html
+++ b/templates/kitchen/ingredients.html
@@ -4,15 +4,16 @@
 <div class="grid">
   <section class="card span-5">
     <h2>{{ '編輯食材' if edit_row else '新增食材' }}</h2>
-    <div class="muted">配方永遠用 g/人；這裡設定實際叫貨單位與價格，例如 kg、箱、斤。</div><br>
+    <div class="muted">先選配方是用「g/人」還是「個/人」，再設定實際採購單位，例如 kg、箱、斤、個。</div><br>
     <form class="main-form" method="post" action="{{ url_for('order_tool.ingredient_update', ingredient_id=edit_row.id) if edit_row else url_for('order_tool.ingredients') }}">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-      <div class="field"><label>食材名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}" placeholder="骨腿丁"></div><br>
+      <div class="field"><label>食材名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}" placeholder="骨腿丁 / 棒棒腿"></div><br>
       <div class="field"><label>預設供應商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}" {% if edit_row and edit_row.supplier_id == s.id %}selected{% endif %}>{{ s.name }}{{ '（停用）' if not s.active else '' }}</option>{% endfor %}</select></div><br>
       <div class="row">
+        <div class="field"><label>配方基本單位</label><select name="base_unit" required>{% for base in base_units %}<option value="{{ base }}" {% if (edit_row.base_unit if edit_row else 'g') == base %}selected{% endif %}>{{ base }}/人</option>{% endfor %}</select><div class="muted">肉丁、蔬菜通常選 g；雞腿、蛋可選 個。</div></div>
         <div class="field"><label>採購單位</label><select name="purchase_unit" required>{% for unit in units %}<option value="{{ unit }}" {% if (edit_row.purchase_unit if edit_row else 'kg') == unit %}selected{% endif %}>{{ unit }}</option>{% endfor %}</select></div>
-        <div class="field"><label>每單位幾克</label><input name="grams_per_purchase_unit" type="number" step="0.001" min="0.001" required value="{{ edit_row.grams_per_purchase_unit if edit_row else 1000 }}"></div>
       </div><br>
+      <div class="field"><label>1 個採購單位包含多少基本單位</label><input name="grams_per_purchase_unit" type="number" step="0.001" min="0.001" required value="{{ edit_row.grams_per_purchase_unit if edit_row else 1000 }}"><div class="muted">例：g + kg 填 1000；個 + 箱（每箱50支）填 50；個 + 個 填 1。</div></div><br>
       <div class="row">
         <div class="field"><label>每採購單位單價（元）</label><input name="unit_price" type="number" step="0.0001" min="0" required value="{{ edit_row.unit_price if edit_row else 0 }}"></div>
         <div class="field"><label>最小叫貨增量</label><input name="order_increment" type="number" step="0.0001" min="0.0001" required value="{{ edit_row.order_increment if edit_row else 0.001 }}"><div class="muted">箱通常填 1；kg 可填 0.001。</div></div>
@@ -26,10 +27,10 @@
   <section class="card span-7">
     <h2>食材清單</h2>
     {% if rows %}<div class="table-scroll"><table>
-      <thead><tr><th>食材</th><th>供應商</th><th>採購規格</th><th class="right">單價</th><th>狀態</th><th>操作</th></tr></thead>
+      <thead><tr><th>食材</th><th>供應商</th><th>配方單位</th><th>採購規格</th><th class="right">單價</th><th>狀態</th><th>操作</th></tr></thead>
       <tbody>{% for r in rows %}<tr>
-        <td>{{ r.name }}</td><td>{{ r.supplier.name if r.supplier else '⚠ 未指定' }}</td>
-        <td>1 {{ r.purchase_unit }} = {{ '%.3f'|format(r.grams_per_purchase_unit|float) }} g<br><span class="muted">增量 {{ r.order_increment }}</span></td>
+        <td>{{ r.name }}</td><td>{{ r.supplier.name if r.supplier else '⚠ 未指定' }}</td><td>{{ r.base_unit or 'g' }}/人</td>
+        <td>1 {{ r.purchase_unit }} = {{ trim_decimal(r.grams_per_purchase_unit) }} {{ r.base_unit or 'g' }}<br><span class="muted">增量 {{ r.order_increment }}</span></td>
         <td class="right">${{ '%.2f'|format(r.unit_price|float) }}/{{ r.purchase_unit }}</td><td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td>
         <td><div class="actions"><a class="btn secondary" href="{{ url_for('order_tool.ingredients', edit=r.id) }}">編輯</a><form method="post" action="{{ url_for('order_tool.ingredient_toggle', ingredient_id=r.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn {{ 'danger' if r.active else 'ok' }}">{{ '停用' if r.active else '恢復' }}</button></form></div></td>
       </tr>{% endfor %}</tbody>

--- a/templates/kitchen/ingredients.html
+++ b/templates/kitchen/ingredients.html
@@ -1,0 +1,39 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}食材{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-5">
+    <h2>{{ '編輯食材' if edit_row else '新增食材' }}</h2>
+    <div class="muted">配方永遠用 g/人；這裡設定實際叫貨單位與價格，例如 kg、箱、斤。</div><br>
+    <form class="main-form" method="post" action="{{ url_for('order_tool.ingredient_update', ingredient_id=edit_row.id) if edit_row else url_for('order_tool.ingredients') }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>食材名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}" placeholder="骨腿丁"></div><br>
+      <div class="field"><label>預設供應商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}" {% if edit_row and edit_row.supplier_id == s.id %}selected{% endif %}>{{ s.name }}{{ '（停用）' if not s.active else '' }}</option>{% endfor %}</select></div><br>
+      <div class="row">
+        <div class="field"><label>採購單位</label><select name="purchase_unit" required>{% for unit in units %}<option value="{{ unit }}" {% if (edit_row.purchase_unit if edit_row else 'kg') == unit %}selected{% endif %}>{{ unit }}</option>{% endfor %}</select></div>
+        <div class="field"><label>每單位幾克</label><input name="grams_per_purchase_unit" type="number" step="0.001" min="0.001" required value="{{ edit_row.grams_per_purchase_unit if edit_row else 1000 }}"></div>
+      </div><br>
+      <div class="row">
+        <div class="field"><label>每採購單位單價（元）</label><input name="unit_price" type="number" step="0.0001" min="0" required value="{{ edit_row.unit_price if edit_row else 0 }}"></div>
+        <div class="field"><label>最小叫貨增量</label><input name="order_increment" type="number" step="0.0001" min="0.0001" required value="{{ edit_row.order_increment if edit_row else 0.001 }}"><div class="muted">箱通常填 1；kg 可填 0.001。</div></div>
+      </div><br>
+      <div class="field"><label>備註</label><textarea name="note">{{ edit_row.note if edit_row and edit_row.note else '' }}</textarea></div><br>
+      <button class="btn">{{ '儲存修改' if edit_row else '新增' }}</button>
+      {% if edit_row %}<a class="btn secondary" href="{{ url_for('order_tool.ingredients') }}">取消</a>{% endif %}
+    </form>
+  </section>
+
+  <section class="card span-7">
+    <h2>食材清單</h2>
+    {% if rows %}<div class="table-scroll"><table>
+      <thead><tr><th>食材</th><th>供應商</th><th>採購規格</th><th class="right">單價</th><th>狀態</th><th>操作</th></tr></thead>
+      <tbody>{% for r in rows %}<tr>
+        <td>{{ r.name }}</td><td>{{ r.supplier.name if r.supplier else '⚠ 未指定' }}</td>
+        <td>1 {{ r.purchase_unit }} = {{ '%.3f'|format(r.grams_per_purchase_unit|float) }} g<br><span class="muted">增量 {{ r.order_increment }}</span></td>
+        <td class="right">${{ '%.2f'|format(r.unit_price|float) }}/{{ r.purchase_unit }}</td><td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td>
+        <td><div class="actions"><a class="btn secondary" href="{{ url_for('order_tool.ingredients', edit=r.id) }}">編輯</a><form method="post" action="{{ url_for('order_tool.ingredient_toggle', ingredient_id=r.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn {{ 'danger' if r.active else 'ok' }}">{{ '停用' if r.active else '恢復' }}</button></form></div></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">尚無資料。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/plan_detail.html
+++ b/templates/kitchen/plan_detail.html
@@ -1,0 +1,45 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}{{ plan.service_date }} {{ plan.name }}{% endblock %}
+{% block content %}
+<div class="top">
+  <div><h1>{{ plan.service_date }}・{{ plan.meal_type }}・{{ plan.name }}</h1><div class="muted">{{ '已確認，菜單已鎖定。' if plan.status == 'confirmed' else '先排菜，再設定每間學校當日人數。' }}</div></div>
+  <a class="btn secondary" href="{{ url_for('order_tool.plans') }}">← 菜單清單</a>
+</div>
+
+{% if has_confirmed_orders %}<div class="notice">這一天已有已確認採購單。歷史採購內容已 snapshot，不會因主檔變更而改變；若要修改本日正式採購，請先到採購單重開草稿。</div>{% endif %}
+
+<div class="grid">
+  <section class="card span-12">
+    <div class="row between center-y"><div><h2>菜單基本資料</h2><span class="pill {{ 'ok' if plan.status == 'confirmed' else 'warn' }}">{{ '已確認' if plan.status == 'confirmed' else '草稿' }}</span></div>
+      <div class="actions no-print">
+        <form method="post" action="{{ url_for('order_tool.plan_copy', plan_id=plan.id) }}" class="row"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input name="target_date" type="date" required><button class="btn secondary">複製到指定日期</button></form>
+        {% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.plan_confirm', plan_id=plan.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn ok">確認菜單</button></form>{% elif not has_confirmed_orders %}<form method="post" action="{{ url_for('order_tool.plan_reopen', plan_id=plan.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn warn">重開草稿</button></form>{% endif %}
+      </div>
+    </div>
+    {% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.plan_update', plan_id=plan.id) }}" class="row main-form"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>日期</label><input name="service_date" type="date" value="{{ plan.service_date }}" required></div><div class="field"><label>餐別</label><select name="meal_type">{% for meal in meal_types %}<option {% if plan.meal_type == meal %}selected{% endif %}>{{ meal }}</option>{% endfor %}</select></div><div class="field"><label>名稱</label><input name="name" value="{{ plan.name }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ plan.note or '' }}"></div><button class="btn">儲存</button></form>{% else %}<div class="muted">備註：{{ plan.note or '無' }}</div>{% endif %}
+  </section>
+
+  <section class="card span-6 {{ 'locked' if plan.status == 'confirmed' else '' }}">
+    <h2>① 今日菜色</h2>
+    {% if plan.items %}<div class="table-scroll"><table><thead><tr><th>分類</th><th>菜色</th><th class="right">AP 生料</th><th></th></tr></thead><tbody>
+      {% for x in plan.items %}<tr><td><span class="pill">{{ x.recipe.category or '-' }}</span></td><td>{{ x.recipe.name }}</td><td class="right">{{ '%.1f'|format(recipe_total_g(x.recipe)|float) }} g/人</td><td>{% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.plan_item_delete', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">移除</button></form>{% endif %}</td></tr>{% endfor %}
+    </tbody></table></div>{% else %}<div class="empty">尚未排菜。</div>{% endif %}
+    {% if plan.status == 'draft' %}<hr><h3>加入菜色</h3>{% if recipes %}<form method="post" action="{{ url_for('order_tool.plan_item_add', plan_id=plan.id) }}" class="row"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><select name="recipe_id">{% for r in recipes %}<option value="{{ r.id }}">{{ r.category or '未分類' }}｜{{ r.name }}</option>{% endfor %}</select></div><button class="btn">加入</button></form>{% else %}<div class="notice">目前沒有啟用中的菜色。</div>{% endif %}{% endif %}
+  </section>
+
+  <section class="card span-6 {{ 'locked' if plan.status == 'confirmed' else '' }}">
+    <h2>② 分配學校 / 人數</h2>
+    {% if plan.assignments %}<div class="table-scroll"><table><thead><tr><th>學校</th><th>當日人數</th><th></th></tr></thead><tbody>
+      {% for x in plan.assignments %}<tr><td>{{ x.school.name }}</td><td>{% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.assignment_update', row_id=x.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input style="max-width:120px" name="headcount" type="number" min="0" value="{{ x.headcount }}" required><button class="btn secondary">更新</button></form>{% else %}{{ x.headcount }}{% endif %}</td><td>{% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.assignment_delete', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">移除</button></form>{% endif %}</td></tr>{% endfor %}
+      <tr><td><b>總人數</b></td><td><b>{{ total_people }}</b></td><td></td></tr>
+    </tbody></table></div>{% else %}<div class="empty">尚未分配學校。</div>{% endif %}
+    {% if plan.status == 'draft' %}<hr><h3>加入學校</h3>{% if schools %}<form method="post" action="{{ url_for('order_tool.assignment_add', plan_id=plan.id) }}" class="row"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>學校</label><select name="school_id">{% for s in schools %}<option value="{{ s.id }}">{{ s.name }}</option>{% endfor %}</select></div><div class="field"><label>當日人數</label><input name="headcount" type="number" min="0" required></div><button class="btn">加入</button></form>{% else %}<div class="notice">目前沒有啟用中的學校。</div>{% endif %}{% endif %}
+  </section>
+
+  <section class="card span-12">
+    <div class="top"><div><h2>③ 採購叫貨</h2><div class="muted">會把同一天所有學校的人數展開配方並依供應商分單。草稿採購量可人工修正，確認後保存 snapshot。</div></div><form method="post" action="{{ url_for('order_tool.generate_purchases') }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="start" value="{{ plan.service_date }}"><input type="hidden" name="end" value="{{ plan.service_date }}"><button class="btn">產生 / 更新今日採購草稿</button></form></div>
+  </section>
+
+  {% if plan.status == 'draft' %}<section class="card span-12 no-print"><div class="row between center-y"><div><h3>刪除草稿菜單</h3><div class="muted">只允許刪除草稿；已確認菜單需先重開。</div></div><form method="post" action="{{ url_for('order_tool.plan_delete', plan_id=plan.id) }}" onsubmit="return confirm('確定刪除這張菜單？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">刪除菜單</button></form></div></section>{% endif %}
+</div>
+{% endblock %}

--- a/templates/kitchen/plan_detail.html
+++ b/templates/kitchen/plan_detail.html
@@ -21,7 +21,8 @@
 
   <section class="card span-6 {{ 'locked' if plan.status == 'confirmed' else '' }}">
     <h2>① 今日菜色</h2>
-    {% if plan.items %}<div class="table-scroll"><table><thead><tr><th>分類</th><th>菜色</th><th class="right">AP 生料</th><th></th></tr></thead><tbody>
+    <div class="muted">下方克數只加總 g 類食材；「個/人」食材仍會在採購計算中正常計入。</div><br>
+    {% if plan.items %}<div class="table-scroll"><table><thead><tr><th>分類</th><th>菜色</th><th class="right">g 類 AP 生料</th><th></th></tr></thead><tbody>
       {% for x in plan.items %}<tr><td><span class="pill">{{ x.recipe.category or '-' }}</span></td><td>{{ x.recipe.name }}</td><td class="right">{{ '%.1f'|format(recipe_total_g(x.recipe)|float) }} g/人</td><td>{% if plan.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.plan_item_delete', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">移除</button></form>{% endif %}</td></tr>{% endfor %}
     </tbody></table></div>{% else %}<div class="empty">尚未排菜。</div>{% endif %}
     {% if plan.status == 'draft' %}<hr><h3>加入菜色</h3>{% if recipes %}<form method="post" action="{{ url_for('order_tool.plan_item_add', plan_id=plan.id) }}" class="row"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><select name="recipe_id">{% for r in recipes %}<option value="{{ r.id }}">{{ r.category or '未分類' }}｜{{ r.name }}</option>{% endfor %}</select></div><button class="btn">加入</button></form>{% else %}<div class="notice">目前沒有啟用中的菜色。</div>{% endif %}{% endif %}
@@ -37,7 +38,7 @@
   </section>
 
   <section class="card span-12">
-    <div class="top"><div><h2>③ 採購叫貨</h2><div class="muted">會把同一天所有學校的人數展開配方並依供應商分單。草稿採購量可人工修正，確認後保存 snapshot。</div></div><form method="post" action="{{ url_for('order_tool.generate_purchases') }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="start" value="{{ plan.service_date }}"><input type="hidden" name="end" value="{{ plan.service_date }}"><button class="btn">產生 / 更新今日採購草稿</button></form></div>
+    <div class="top"><div><h2>③ 採購叫貨</h2><div class="muted">會把同一天所有學校的人數展開配方並依供應商分單。草稿採購量可人工修正；重新計算需求時人工調整會保留，確認後保存 snapshot。</div></div><form method="post" action="{{ url_for('order_tool.generate_purchases') }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="start" value="{{ plan.service_date }}"><input type="hidden" name="end" value="{{ plan.service_date }}"><button class="btn">產生 / 更新今日採購草稿</button></form></div>
   </section>
 
   {% if plan.status == 'draft' %}<section class="card span-12 no-print"><div class="row between center-y"><div><h3>刪除草稿菜單</h3><div class="muted">只允許刪除草稿；已確認菜單需先重開。</div></div><form method="post" action="{{ url_for('order_tool.plan_delete', plan_id=plan.id) }}" onsubmit="return confirm('確定刪除這張菜單？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">刪除菜單</button></form></div></section>{% endif %}

--- a/templates/kitchen/plans.html
+++ b/templates/kitchen/plans.html
@@ -1,0 +1,30 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}菜單{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-4">
+    <h2>建立中央菜單</h2>
+    <form class="main-form" method="post">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>供餐日期</label><input name="service_date" type="date" value="{{ today }}" required></div><br>
+      <div class="field"><label>餐別</label><select name="meal_type">{% for meal in meal_types %}<option value="{{ meal }}" {% if meal == '午餐' %}selected{% endif %}>{{ meal }}</option>{% endfor %}</select></div><br>
+      <div class="field"><label>菜單名稱</label><input name="name" value="中央菜單" required></div><br>
+      <div class="field"><label>備註</label><textarea name="note"></textarea></div><br>
+      <button class="btn">建立並排菜</button>
+    </form>
+  </section>
+
+  <section class="card span-8">
+    <div class="top"><div><h2>{{ start }} 起 14 天</h2><div class="muted">可建立多個餐別或不同菜單。</div></div><form method="get" class="row"><div class="field"><label>起始日</label><input name="start" type="date" value="{{ start }}"></div><button class="btn secondary">查看</button></form></div>
+    {% if rows %}<div class="table-scroll"><table>
+      <thead><tr><th>日期</th><th>餐別</th><th>菜單</th><th>菜色</th><th>供餐</th><th>狀態</th><th></th></tr></thead>
+      <tbody>{% for p in rows %}<tr><td>{{ p.service_date }}</td><td>{{ p.meal_type }}</td><td>{{ p.name }}</td><td>{{ p.items|length }} 道</td><td>{{ p.assignments|length }} 校 / {{ p.assignments|sum(attribute='headcount') }} 人</td><td><span class="pill {{ 'ok' if p.status == 'confirmed' else 'warn' }}">{{ '已確認' if p.status == 'confirmed' else '草稿' }}</span></td><td><a href="{{ url_for('order_tool.plan_detail', plan_id=p.id) }}">編輯</a></td></tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">這段期間沒有菜單。</div>{% endif %}
+  </section>
+
+  <section class="card span-12">
+    <h2>週菜單預覽</h2>
+    <div class="week-grid">{% for day in days %}<div class="day-card"><div class="date">{{ day.date }}<br><span class="muted">{{ day.weekday }}</span></div>{% if day.plans %}{% for p in day.plans %}<div class="dish"><b>{{ p.meal_type }}</b>｜{{ p.name }}</div>{% for item in p.items %}<div class="dish"><span class="pill">{{ item.recipe.category or '-' }}</span> {{ item.recipe.name }}</div>{% endfor %}{% endfor %}{% else %}<div class="muted">尚無菜單</div>{% endif %}</div>{% endfor %}</div>
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/purchase_detail.html
+++ b/templates/kitchen/purchase_detail.html
@@ -1,23 +1,23 @@
 {% extends 'kitchen/base.html' %}
 {% block title %}採購單 {{ order.service_date }} {{ order.supplier_name_snapshot }}{% endblock %}
 {% block content %}
-<div class="print-title"><h1>每日訂購單</h1><div>{{ order.service_date }}｜{{ order.supplier_name_snapshot }}</div></div>
+<div class="print-title"><h1>{{ '每日訂購單' if order.status == 'confirmed' else '採購草稿－不可叫貨' }}</h1><div>{{ order.service_date }}｜{{ order.supplier_name_snapshot }}</div></div>
 <div class="top">
   <div><h1>{{ order.service_date }}｜{{ order.supplier_name_snapshot }}</h1><div class="muted">採購單 #{{ order.id }}・{{ status_label(order.status) }}</div></div>
-  <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.purchases', start=order.service_date, end=order.service_date) }}">← 採購歷史</a><a class="btn" href="{{ url_for('order_tool.purchase_detail', order_id=order.id, print=1) }}" target="_blank">列印 / 另存 PDF</a></div>
+  <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.purchases', start=order.service_date, end=order.service_date) }}">← 採購歷史</a>{% if order.status == 'confirmed' %}<a class="btn" href="{{ url_for('order_tool.purchase_detail', order_id=order.id, print=1) }}" target="_blank">列印 / 另存 PDF</a>{% endif %}</div>
 </div>
 
-{% if order.status == 'confirmed' %}<div class="flash success">此單已確認並保存 snapshot。之後修改食材價格或菜色配方，不會改變這張歷史採購單。</div>{% elif order.status == 'cancelled' %}<div class="flash warning">此單已取消；如需重新使用，請重開草稿。</div>{% endif %}
+{% if order.status == 'confirmed' %}<div class="flash success">此單已確認並保存 snapshot。之後修改食材價格或菜色配方，不會改變這張歷史採購單。</div>{% elif order.status == 'cancelled' %}<div class="flash warning">此單已取消；如需重新使用，請重開草稿。</div>{% else %}<div class="flash warning">目前是草稿，請先確認「實際叫貨量、單價、廠商」再按「確認叫貨單」。草稿不提供正式 PDF，避免誤拿去叫貨。</div>{% endif %}
 
 <div class="grid">
   <section class="card span-12 no-print">
     <div class="row between center-y">
       <div><h2>採購單設定</h2><span class="pill {{ 'ok' if order.status == 'confirmed' else ('off' if order.status == 'cancelled' else 'warn') }}">{{ status_label(order.status) }}</span></div>
       <div class="actions">
-        {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_confirm', order_id=order.id) }}" onsubmit="return confirm('確認後這張採購單會鎖定為歷史 snapshot，確定嗎？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn ok">確認叫貨單</button></form><form method="post" action="{{ url_for('order_tool.purchase_cancel', order_id=order.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">取消</button></form>{% else %}<form method="post" action="{{ url_for('order_tool.purchase_reopen', order_id=order.id) }}" onsubmit="return confirm('重開後可修改這張單，確定嗎？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn warn">重開草稿</button></form>{% endif %}
+        {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_confirm', order_id=order.id) }}" onsubmit="return confirm('你已核對廠商、實際叫貨量與單價嗎？確認後會鎖定為歷史叫貨單。')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn ok">確認叫貨單</button></form><form method="post" action="{{ url_for('order_tool.purchase_cancel', order_id=order.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">取消</button></form>{% else %}<form method="post" action="{{ url_for('order_tool.purchase_reopen', order_id=order.id) }}" onsubmit="return confirm('重開後可修改這張單，確定嗎？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn warn">重開草稿</button></form>{% endif %}
       </div>
     </div>
-    {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_update', order_id=order.id) }}" class="row main-form"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>廠商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}" {% if order.supplier_id == s.id %}selected{% endif %}>{{ s.name }}{{ '（停用）' if not s.active else '' }}</option>{% endfor %}</select></div><div class="field"><label>備註</label><input name="note" value="{{ order.note or '' }}"></div><button class="btn">儲存單頭</button></form>{% else %}<div class="muted">備註：{{ order.note or '無' }}</div>{% endif %}
+    {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_update', order_id=order.id) }}" class="row main-form"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>廠商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}" {% if order.supplier_id == s.id %}selected{% endif %}>{{ s.name }}{{ '（停用）' if not s.active else '' }}</option>{% endfor %}</select></div><div class="field"><label>整張單備註</label><input name="note" value="{{ order.note or '' }}"></div><button class="btn">儲存單頭</button></form>{% else %}<div class="muted">備註：{{ order.note or '無' }}</div>{% endif %}
   </section>
 
   <section class="card span-12 purchase-group">
@@ -29,11 +29,11 @@
         <td class="right"><b>{{ '%.3f'|format((item.required_grams|float)/1000) }} kg</b><br><span class="muted">{{ '%.0f'|format(item.required_grams|float) }} g</span></td>
         <td class="right">{{ '%.4f'|format(item.required_qty|float) }} {{ item.purchase_unit_snapshot }}</td>
         <td class="right"><b>{{ trim_decimal(item.recommended_order_qty) }} {{ item.purchase_unit_snapshot }}</b></td>
-        {% if order.status == 'draft' %}<td colspan="4"><form method="post" action="{{ url_for('order_tool.purchase_item_update', item_id=item.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>實際數量</label><input name="actual_order_qty" type="number" min="0" step="0.0001" value="{{ item.actual_order_qty }}" required></div><div class="field"><label>單價 / {{ item.purchase_unit_snapshot }}</label><input name="unit_price" type="number" min="0" step="0.0001" value="{{ item.unit_price_snapshot }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ item.note or '' }}"></div><button class="btn secondary">更新</button></form><div class="right"><b>目前金額 ${{ '%.2f'|format(item.amount|float) }}</b></div></td>
+        {% if order.status == 'draft' %}<td colspan="4"><form method="post" action="{{ url_for('order_tool.purchase_item_update', item_id=item.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>實際數量</label><input name="actual_order_qty" type="number" min="0" step="0.0001" value="{{ item.actual_order_qty }}" required></div><div class="field"><label>單價 / {{ item.purchase_unit_snapshot }}</label><input name="unit_price" type="number" min="0" step="0.0001" value="{{ item.unit_price_snapshot }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ item.note or '' }}"></div><button class="btn secondary">更新這項</button></form><div class="right"><b>目前金額 ${{ '%.2f'|format(item.amount|float) }}</b></div></td>
         {% else %}<td>{{ trim_decimal(item.actual_order_qty) }} {{ item.purchase_unit_snapshot }}</td><td>${{ '%.4f'|format(item.unit_price_snapshot|float) }}/{{ item.purchase_unit_snapshot }}</td><td class="right">${{ '%.2f'|format(item.amount|float) }}</td><td>{{ item.note or '-' }}</td>{% endif %}
       </tr>{% endfor %}</tbody>
     </table></div>{% else %}<div class="empty">此採購單沒有項目。</div>{% endif %}
   </section>
 </div>
-{% if do_print %}<script>window.addEventListener('load',()=>window.print());</script>{% endif %}
+{% if do_print and order.status == 'confirmed' %}<script>window.addEventListener('load',()=>window.print());</script>{% endif %}
 {% endblock %}

--- a/templates/kitchen/purchase_detail.html
+++ b/templates/kitchen/purchase_detail.html
@@ -7,7 +7,7 @@
   <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.purchases', start=order.service_date, end=order.service_date) }}">← 採購歷史</a>{% if order.status == 'confirmed' %}<a class="btn" href="{{ url_for('order_tool.purchase_detail', order_id=order.id, print=1) }}" target="_blank">列印 / 另存 PDF</a>{% endif %}</div>
 </div>
 
-{% if order.status == 'confirmed' %}<div class="flash success">此單已確認並保存 snapshot。之後修改食材價格或菜色配方，不會改變這張歷史採購單。</div>{% elif order.status == 'cancelled' %}<div class="flash warning">此單已取消；如需重新使用，請重開草稿。</div>{% else %}<div class="flash warning">目前是草稿，請先確認「實際叫貨量、單價、廠商」再按「確認叫貨單」。草稿不提供正式 PDF，避免誤拿去叫貨。</div>{% endif %}
+{% if order.status == 'confirmed' %}<div class="flash success">此單已確認並保存 snapshot。之後修改食材價格或菜色配方，不會改變這張歷史採購單。</div>{% elif order.status == 'cancelled' %}<div class="flash warning">此單已取消；重新產生該日期需求時可重新啟用為草稿。</div>{% else %}<div class="flash warning">目前是草稿，請先確認「實際叫貨量、單價、廠商」再按「確認叫貨單」。草稿不提供正式 PDF，避免誤拿去叫貨。</div>{% endif %}
 
 <div class="grid">
   <section class="card span-12 no-print">
@@ -26,10 +26,10 @@
       <thead><tr><th>食材</th><th class="right">需求量</th><th class="right">需求換算</th><th class="right">建議叫貨</th><th>實際叫貨</th><th>單價</th><th class="right">金額</th><th>備註</th></tr></thead>
       <tbody>{% for item in order.items %}<tr>
         <td>{{ item.ingredient_name_snapshot }}</td>
-        <td class="right"><b>{{ '%.3f'|format((item.required_grams|float)/1000) }} kg</b><br><span class="muted">{{ '%.0f'|format(item.required_grams|float) }} g</span></td>
-        <td class="right">{{ '%.4f'|format(item.required_qty|float) }} {{ item.purchase_unit_snapshot }}</td>
+        <td class="right"><b>{{ required_display(item) }}</b></td>
+        <td class="right">{{ trim_decimal(item.required_qty) }} {{ item.purchase_unit_snapshot }}</td>
         <td class="right"><b>{{ trim_decimal(item.recommended_order_qty) }} {{ item.purchase_unit_snapshot }}</b></td>
-        {% if order.status == 'draft' %}<td colspan="4"><form method="post" action="{{ url_for('order_tool.purchase_item_update', item_id=item.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>實際數量</label><input name="actual_order_qty" type="number" min="0" step="0.0001" value="{{ item.actual_order_qty }}" required></div><div class="field"><label>單價 / {{ item.purchase_unit_snapshot }}</label><input name="unit_price" type="number" min="0" step="0.0001" value="{{ item.unit_price_snapshot }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ item.note or '' }}"></div><button class="btn secondary">更新這項</button></form><div class="right"><b>目前金額 ${{ '%.2f'|format(item.amount|float) }}</b></div></td>
+        {% if order.status == 'draft' %}<td colspan="4"><form method="post" action="{{ url_for('order_tool.purchase_item_update', item_id=item.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>實際數量</label><input name="actual_order_qty" type="number" min="0" step="0.0001" value="{{ item.actual_order_qty }}" required></div><div class="field"><label>單價 / {{ item.purchase_unit_snapshot }}</label><input name="unit_price" type="number" min="0" step="0.0001" value="{{ item.unit_price_snapshot }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ item.note or '' }}"></div><button class="btn secondary">更新這項</button></form><div class="right"><b>目前金額 ${{ '%.2f'|format(item.amount|float) }}</b>{% if item.manual_override %}<br><span class="pill warn">人工調整，重新計算會保留</span>{% endif %}</div></td>
         {% else %}<td>{{ trim_decimal(item.actual_order_qty) }} {{ item.purchase_unit_snapshot }}</td><td>${{ '%.4f'|format(item.unit_price_snapshot|float) }}/{{ item.purchase_unit_snapshot }}</td><td class="right">${{ '%.2f'|format(item.amount|float) }}</td><td>{{ item.note or '-' }}</td>{% endif %}
       </tr>{% endfor %}</tbody>
     </table></div>{% else %}<div class="empty">此採購單沒有項目。</div>{% endif %}

--- a/templates/kitchen/purchase_detail.html
+++ b/templates/kitchen/purchase_detail.html
@@ -1,0 +1,39 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}採購單 {{ order.service_date }} {{ order.supplier_name_snapshot }}{% endblock %}
+{% block content %}
+<div class="print-title"><h1>每日訂購單</h1><div>{{ order.service_date }}｜{{ order.supplier_name_snapshot }}</div></div>
+<div class="top">
+  <div><h1>{{ order.service_date }}｜{{ order.supplier_name_snapshot }}</h1><div class="muted">採購單 #{{ order.id }}・{{ status_label(order.status) }}</div></div>
+  <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.purchases', start=order.service_date, end=order.service_date) }}">← 採購歷史</a><a class="btn" href="{{ url_for('order_tool.purchase_detail', order_id=order.id, print=1) }}" target="_blank">列印 / 另存 PDF</a></div>
+</div>
+
+{% if order.status == 'confirmed' %}<div class="flash success">此單已確認並保存 snapshot。之後修改食材價格或菜色配方，不會改變這張歷史採購單。</div>{% elif order.status == 'cancelled' %}<div class="flash warning">此單已取消；如需重新使用，請重開草稿。</div>{% endif %}
+
+<div class="grid">
+  <section class="card span-12 no-print">
+    <div class="row between center-y">
+      <div><h2>採購單設定</h2><span class="pill {{ 'ok' if order.status == 'confirmed' else ('off' if order.status == 'cancelled' else 'warn') }}">{{ status_label(order.status) }}</span></div>
+      <div class="actions">
+        {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_confirm', order_id=order.id) }}" onsubmit="return confirm('確認後這張採購單會鎖定為歷史 snapshot，確定嗎？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn ok">確認叫貨單</button></form><form method="post" action="{{ url_for('order_tool.purchase_cancel', order_id=order.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">取消</button></form>{% else %}<form method="post" action="{{ url_for('order_tool.purchase_reopen', order_id=order.id) }}" onsubmit="return confirm('重開後可修改這張單，確定嗎？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn warn">重開草稿</button></form>{% endif %}
+      </div>
+    </div>
+    {% if order.status == 'draft' %}<form method="post" action="{{ url_for('order_tool.purchase_update', order_id=order.id) }}" class="row main-form"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>廠商</label><select name="supplier_id"><option value="">未指定</option>{% for s in suppliers %}<option value="{{ s.id }}" {% if order.supplier_id == s.id %}selected{% endif %}>{{ s.name }}{{ '（停用）' if not s.active else '' }}</option>{% endfor %}</select></div><div class="field"><label>備註</label><input name="note" value="{{ order.note or '' }}"></div><button class="btn">儲存單頭</button></form>{% else %}<div class="muted">備註：{{ order.note or '無' }}</div>{% endif %}
+  </section>
+
+  <section class="card span-12 purchase-group">
+    <div class="top"><div><h2>{{ order.supplier_name_snapshot }}</h2><div class="muted">進貨 / 供餐日期：{{ order.service_date }}</div></div><div class="purchase-total">總額 ${{ '%.2f'|format(total|float) }}</div></div>
+    {% if order.items %}<div class="table-scroll"><table>
+      <thead><tr><th>食材</th><th class="right">需求量</th><th class="right">需求換算</th><th class="right">建議叫貨</th><th>實際叫貨</th><th>單價</th><th class="right">金額</th><th>備註</th></tr></thead>
+      <tbody>{% for item in order.items %}<tr>
+        <td>{{ item.ingredient_name_snapshot }}</td>
+        <td class="right"><b>{{ '%.3f'|format((item.required_grams|float)/1000) }} kg</b><br><span class="muted">{{ '%.0f'|format(item.required_grams|float) }} g</span></td>
+        <td class="right">{{ '%.4f'|format(item.required_qty|float) }} {{ item.purchase_unit_snapshot }}</td>
+        <td class="right"><b>{{ trim_decimal(item.recommended_order_qty) }} {{ item.purchase_unit_snapshot }}</b></td>
+        {% if order.status == 'draft' %}<td colspan="4"><form method="post" action="{{ url_for('order_tool.purchase_item_update', item_id=item.id) }}" class="row center-y"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><div class="field"><label>實際數量</label><input name="actual_order_qty" type="number" min="0" step="0.0001" value="{{ item.actual_order_qty }}" required></div><div class="field"><label>單價 / {{ item.purchase_unit_snapshot }}</label><input name="unit_price" type="number" min="0" step="0.0001" value="{{ item.unit_price_snapshot }}" required></div><div class="field"><label>備註</label><input name="note" value="{{ item.note or '' }}"></div><button class="btn secondary">更新</button></form><div class="right"><b>目前金額 ${{ '%.2f'|format(item.amount|float) }}</b></div></td>
+        {% else %}<td>{{ trim_decimal(item.actual_order_qty) }} {{ item.purchase_unit_snapshot }}</td><td>${{ '%.4f'|format(item.unit_price_snapshot|float) }}/{{ item.purchase_unit_snapshot }}</td><td class="right">${{ '%.2f'|format(item.amount|float) }}</td><td>{{ item.note or '-' }}</td>{% endif %}
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">此採購單沒有項目。</div>{% endif %}
+  </section>
+</div>
+{% if do_print %}<script>window.addEventListener('load',()=>window.print());</script>{% endif %}
+{% endblock %}

--- a/templates/kitchen/purchases.html
+++ b/templates/kitchen/purchases.html
@@ -1,0 +1,25 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}採購叫貨{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-12">
+    <div class="top"><div><h2>產生採購草稿</h2><div class="muted">依菜單、各校人數與配方計算需求；只會更新草稿，不會覆蓋已確認歷史單。</div></div></div>
+    <form method="post" action="{{ url_for('order_tool.generate_purchases') }}" class="row main-form">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>開始日期</label><input name="start" type="date" value="{{ start }}" required></div>
+      <div class="field"><label>結束日期</label><input name="end" type="date" value="{{ end }}" required></div>
+      <button class="btn">產生 / 更新草稿</button>
+    </form>
+  </section>
+
+  <section class="card span-12">
+    <div class="top"><div><h2>採購單歷史</h2><div class="muted">已確認單據保存當時的需求量、採購規格、單價與實際叫貨量。</div></div><form method="get" class="row"><div class="field"><label>開始</label><input name="start" type="date" value="{{ start }}"></div><div class="field"><label>結束</label><input name="end" type="date" value="{{ end }}"></div><button class="btn secondary">篩選</button></form></div>
+    {% if orders %}<div class="table-scroll"><table>
+      <thead><tr><th>日期</th><th>廠商</th><th>狀態</th><th>項目</th><th class="right">金額</th><th>更新時間</th><th></th></tr></thead>
+      <tbody>{% for o in orders %}<tr>
+        <td>{{ o.service_date }}</td><td>{{ o.supplier_name_snapshot }}</td><td><span class="pill {{ 'ok' if o.status == 'confirmed' else ('off' if o.status == 'cancelled' else 'warn') }}">{{ status_label(o.status) }}</span></td><td>{{ o.items|length }}</td><td class="right">${{ '%.2f'|format(order_total(o)|float) }}</td><td>{{ o.updated_at.strftime('%Y-%m-%d %H:%M') if o.updated_at else '-' }}</td><td><a class="btn secondary" href="{{ url_for('order_tool.purchase_detail', order_id=o.id) }}">開啟</a></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">這段期間沒有採購單。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/recipe_detail.html
+++ b/templates/kitchen/recipe_detail.html
@@ -1,0 +1,36 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}{{ recipe.name }}{% endblock %}
+{% block content %}
+<div class="top">
+  <div><h1>{{ recipe.name }}</h1><div class="muted">每人 AP 採購配方。打菜量 {{ recipe.serving_output_g if recipe.serving_output_g is not none else '-' }} g/人。</div></div>
+  <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.recipes') }}">← 菜色清單</a><form method="post" action="{{ url_for('order_tool.recipe_copy', recipe_id=recipe.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn">複製此菜色</button></form></div>
+</div>
+
+<div class="grid">
+  <section class="card span-8">
+    <h2>目前配方</h2>
+    {% if recipe.ingredients %}<div class="table-scroll"><table>
+      <thead><tr><th>食材</th><th>每人 AP</th><th>採購單價</th><th class="right">每人成本</th><th>修改</th></tr></thead>
+      <tbody>{% for x in recipe.ingredients %}<tr>
+        <td>{{ x.ingredient.name }}{% if not x.ingredient.active %}<br><span class="pill off">食材已停用</span>{% endif %}</td>
+        <td><form class="row center-y" method="post" action="{{ url_for('order_tool.recipe_ingredient_update', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input style="max-width:120px" name="grams_per_person" type="number" min="0.001" step="0.001" value="{{ x.grams_per_person }}" required><span>g</span><button class="btn secondary">更新</button></form></td>
+        <td>${{ '%.2f'|format(x.ingredient.unit_price|float) }}/{{ x.ingredient.purchase_unit }}</td>
+        <td class="right">${{ '%.3f'|format(component_cost(x)|float) }}</td>
+        <td><form method="post" action="{{ url_for('order_tool.recipe_ingredient_delete', row_id=x.id) }}" onsubmit="return confirm('確定移除此食材？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">移除</button></form></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>
+    <hr><div class="row between center-y"><b>每份 AP 生料：{{ '%.1f'|format(total_g|float) }} g</b><b>每份原料成本：約 ${{ '%.2f'|format(total_cost|float) }}</b></div>
+    {% else %}<div class="empty">還沒有食材。</div>{% endif %}
+  </section>
+
+  <section class="card span-4">
+    <h2>加入食材</h2>
+    {% if ingredients %}<form class="main-form" method="post" action="{{ url_for('order_tool.recipe_ingredient_add', recipe_id=recipe.id) }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>食材</label><select name="ingredient_id" required>{% for i in ingredients %}<option value="{{ i.id }}">{{ i.name }}｜{{ i.purchase_unit }}</option>{% endfor %}</select></div><br>
+      <div class="field"><label>每人 AP 採購量（g）</label><input name="grams_per_person" type="number" min="0.001" step="0.001" required placeholder="例如 88"></div><br>
+      <button class="btn">加入配方</button>
+    </form>{% else %}<div class="notice">沒有可用食材，請先建立或恢復食材。</div><a class="btn" href="{{ url_for('order_tool.ingredients') }}">去建立食材</a>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/recipe_detail.html
+++ b/templates/kitchen/recipe_detail.html
@@ -2,7 +2,7 @@
 {% block title %}{{ recipe.name }}{% endblock %}
 {% block content %}
 <div class="top">
-  <div><h1>{{ recipe.name }}</h1><div class="muted">每人 AP 採購配方。打菜量 {{ recipe.serving_output_g if recipe.serving_output_g is not none else '-' }} g/人。</div></div>
+  <div><h1>{{ recipe.name }}</h1><div class="muted">每人 AP 採購配方；食材可各自使用 g/人 或 個/人。打菜量 {{ recipe.serving_output_g if recipe.serving_output_g is not none else '-' }} g/人。</div></div>
   <div class="actions no-print"><a class="btn secondary" href="{{ url_for('order_tool.recipes') }}">← 菜色清單</a><form method="post" action="{{ url_for('order_tool.recipe_copy', recipe_id=recipe.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn">複製此菜色</button></form></div>
 </div>
 
@@ -10,16 +10,17 @@
   <section class="card span-8">
     <h2>目前配方</h2>
     {% if recipe.ingredients %}<div class="table-scroll"><table>
-      <thead><tr><th>食材</th><th>每人 AP</th><th>採購單價</th><th class="right">每人成本</th><th>修改</th></tr></thead>
+      <thead><tr><th>食材</th><th>每人 AP</th><th>採購規格 / 單價</th><th class="right">每人成本</th><th>修改</th></tr></thead>
       <tbody>{% for x in recipe.ingredients %}<tr>
         <td>{{ x.ingredient.name }}{% if not x.ingredient.active %}<br><span class="pill off">食材已停用</span>{% endif %}</td>
-        <td><form class="row center-y" method="post" action="{{ url_for('order_tool.recipe_ingredient_update', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input style="max-width:120px" name="grams_per_person" type="number" min="0.001" step="0.001" value="{{ x.grams_per_person }}" required><span>g</span><button class="btn secondary">更新</button></form></td>
-        <td>${{ '%.2f'|format(x.ingredient.unit_price|float) }}/{{ x.ingredient.purchase_unit }}</td>
+        <td><form class="row center-y" method="post" action="{{ url_for('order_tool.recipe_ingredient_update', row_id=x.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><input style="max-width:120px" name="grams_per_person" type="number" min="0.001" step="0.001" value="{{ x.grams_per_person }}" required><span>{{ x.ingredient.base_unit or 'g' }}/人</span><button class="btn secondary">更新</button></form></td>
+        <td>1 {{ x.ingredient.purchase_unit }} = {{ trim_decimal(x.ingredient.grams_per_purchase_unit) }} {{ x.ingredient.base_unit or 'g' }}<br><span class="muted">${{ '%.2f'|format(x.ingredient.unit_price|float) }}/{{ x.ingredient.purchase_unit }}</span></td>
         <td class="right">${{ '%.3f'|format(component_cost(x)|float) }}</td>
         <td><form method="post" action="{{ url_for('order_tool.recipe_ingredient_delete', row_id=x.id) }}" onsubmit="return confirm('確定移除此食材？')"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn danger">移除</button></form></td>
       </tr>{% endfor %}</tbody>
     </table></div>
-    <hr><div class="row between center-y"><b>每份 AP 生料：{{ '%.1f'|format(total_g|float) }} g</b><b>每份原料成本：約 ${{ '%.2f'|format(total_cost|float) }}</b></div>
+    <hr><div class="row between center-y"><b>每份 g 類生料合計：{{ '%.1f'|format(total_g|float) }} g</b><b>每份原料成本：約 ${{ '%.2f'|format(total_cost|float) }}</b></div>
+    <div class="muted">「個」類食材不會硬加進克數合計，但仍會正常計入採購量與成本。</div>
     {% else %}<div class="empty">還沒有食材。</div>{% endif %}
   </section>
 
@@ -27,8 +28,8 @@
     <h2>加入食材</h2>
     {% if ingredients %}<form class="main-form" method="post" action="{{ url_for('order_tool.recipe_ingredient_add', recipe_id=recipe.id) }}">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-      <div class="field"><label>食材</label><select name="ingredient_id" required>{% for i in ingredients %}<option value="{{ i.id }}">{{ i.name }}｜{{ i.purchase_unit }}</option>{% endfor %}</select></div><br>
-      <div class="field"><label>每人 AP 採購量（g）</label><input name="grams_per_person" type="number" min="0.001" step="0.001" required placeholder="例如 88"></div><br>
+      <div class="field"><label>食材</label><select name="ingredient_id" required>{% for i in ingredients %}<option value="{{ i.id }}">{{ i.name }}｜{{ i.base_unit or 'g' }}/人｜採購 {{ i.purchase_unit }}</option>{% endfor %}</select></div><br>
+      <div class="field"><label>每人 AP 用量</label><input name="grams_per_person" type="number" min="0.001" step="0.001" required placeholder="骨腿丁填88；棒棒腿填1"><div class="muted">單位跟著上面食材設定：g/人 或 個/人。</div></div><br>
       <button class="btn">加入配方</button>
     </form>{% else %}<div class="notice">沒有可用食材，請先建立或恢復食材。</div><a class="btn" href="{{ url_for('order_tool.ingredients') }}">去建立食材</a>{% endif %}
   </section>

--- a/templates/kitchen/recipes.html
+++ b/templates/kitchen/recipes.html
@@ -17,8 +17,9 @@
 
   <section class="card span-7">
     <h2>菜色清單</h2>
+    <div class="muted">這裡的生料合計只加總 g 類食材；「個/人」食材請點進配方查看。</div><br>
     {% if rows %}<div class="table-scroll"><table>
-      <thead><tr><th>分類</th><th>菜色</th><th class="right">AP 生料</th><th class="right">打菜量</th><th>狀態</th><th>操作</th></tr></thead>
+      <thead><tr><th>分類</th><th>菜色</th><th class="right">g 類 AP 生料</th><th class="right">打菜量</th><th>狀態</th><th>操作</th></tr></thead>
       <tbody>{% for r in rows %}<tr>
         <td><span class="pill">{{ r.category or '未分類' }}</span></td><td>{{ r.name }}</td><td class="right">{{ '%.1f'|format(recipe_total_g(r)|float) }} g/人</td><td class="right">{{ ('%.1f'|format(r.serving_output_g|float) ~ ' g') if r.serving_output_g is not none else '-' }}</td>
         <td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td>

--- a/templates/kitchen/recipes.html
+++ b/templates/kitchen/recipes.html
@@ -1,0 +1,30 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}菜色配方{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-5">
+    <h2>{{ '編輯菜色' if edit_row else '新增菜色' }}</h2>
+    <form class="main-form" method="post" action="{{ url_for('order_tool.recipe_update', recipe_id=edit_row.id) if edit_row else url_for('order_tool.recipes') }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>菜色名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}" placeholder="南洋綠咖哩雞"></div><br>
+      <div class="field"><label>分類</label><select name="category">{% for c in categories %}<option value="{{ c }}" {% if (edit_row.category if edit_row else '主菜') == c %}selected{% endif %}>{{ c }}</option>{% endfor %}</select></div><br>
+      <div class="field"><label>預計打菜量 g / 人（可空白）</label><input name="serving_output_g" type="number" step="0.01" min="0" value="{{ edit_row.serving_output_g if edit_row and edit_row.serving_output_g is not none else '' }}" placeholder="95"><div class="muted">這是成品分餐量，不參與 AP 食材採購計算。</div></div><br>
+      <div class="field"><label>備註</label><textarea name="note">{{ edit_row.note if edit_row and edit_row.note else '' }}</textarea></div><br>
+      <button class="btn">{{ '儲存修改' if edit_row else '建立後設定配方' }}</button>
+      {% if edit_row %}<a class="btn secondary" href="{{ url_for('order_tool.recipes') }}">取消</a>{% endif %}
+    </form>
+  </section>
+
+  <section class="card span-7">
+    <h2>菜色清單</h2>
+    {% if rows %}<div class="table-scroll"><table>
+      <thead><tr><th>分類</th><th>菜色</th><th class="right">AP 生料</th><th class="right">打菜量</th><th>狀態</th><th>操作</th></tr></thead>
+      <tbody>{% for r in rows %}<tr>
+        <td><span class="pill">{{ r.category or '未分類' }}</span></td><td>{{ r.name }}</td><td class="right">{{ '%.1f'|format(recipe_total_g(r)|float) }} g/人</td><td class="right">{{ ('%.1f'|format(r.serving_output_g|float) ~ ' g') if r.serving_output_g is not none else '-' }}</td>
+        <td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td>
+        <td><div class="actions"><a class="btn secondary" href="{{ url_for('order_tool.recipe_detail', recipe_id=r.id) }}">配方</a><a class="btn secondary" href="{{ url_for('order_tool.recipes', edit=r.id) }}">編輯</a><form method="post" action="{{ url_for('order_tool.recipe_toggle', recipe_id=r.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn {{ 'danger' if r.active else 'ok' }}">{{ '停用' if r.active else '恢復' }}</button></form></div></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">先建立第一道菜。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/schools.html
+++ b/templates/kitchen/schools.html
@@ -1,0 +1,29 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}學校 / 客戶{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-5">
+    <h2>{{ '編輯學校 / 客戶' if edit_row else '新增學校 / 客戶' }}</h2>
+    <form class="main-form" method="post" action="{{ url_for('order_tool.school_update', school_id=edit_row.id) if edit_row else url_for('order_tool.schools') }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}" placeholder="例如：內小"></div><br>
+      <div class="field"><label>代碼（可空白）</label><input name="code" value="{{ edit_row.code if edit_row and edit_row.code else '' }}" placeholder="例如：1-08"></div><br>
+      <button class="btn">{{ '儲存修改' if edit_row else '新增' }}</button>
+      {% if edit_row %}<a class="btn secondary" href="{{ url_for('order_tool.schools') }}">取消</a>{% endif %}
+    </form>
+  </section>
+
+  <section class="card span-7">
+    <h2>學校清單</h2>
+    {% if rows %}<div class="table-scroll"><table>
+      <thead><tr><th>代碼</th><th>名稱</th><th>狀態</th><th>操作</th></tr></thead>
+      <tbody>{% for r in rows %}<tr>
+        <td>{{ r.code or '-' }}</td><td>{{ r.name }}</td><td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td>
+        <td><div class="actions"><a class="btn secondary" href="{{ url_for('order_tool.schools', edit=r.id) }}">編輯</a>
+          <form method="post" action="{{ url_for('order_tool.school_toggle', school_id=r.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn {{ 'danger' if r.active else 'ok' }}">{{ '停用' if r.active else '恢復' }}</button></form>
+        </div></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">尚無資料。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/kitchen/suppliers.html
+++ b/templates/kitchen/suppliers.html
@@ -1,0 +1,30 @@
+{% extends 'kitchen/base.html' %}
+{% block title %}廠商{% endblock %}
+{% block content %}
+<div class="grid">
+  <section class="card span-5">
+    <h2>{{ '編輯廠商' if edit_row else '新增廠商' }}</h2>
+    <form class="main-form" method="post" action="{{ url_for('order_tool.supplier_update', supplier_id=edit_row.id) if edit_row else url_for('order_tool.suppliers') }}">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="field"><label>廠商名稱</label><input name="name" required value="{{ edit_row.name if edit_row else '' }}"></div><br>
+      <div class="field"><label>電話</label><input name="phone" value="{{ edit_row.phone if edit_row and edit_row.phone else '' }}"></div><br>
+      <div class="field"><label>備註</label><textarea name="note">{{ edit_row.note if edit_row and edit_row.note else '' }}</textarea></div><br>
+      <button class="btn">{{ '儲存修改' if edit_row else '新增' }}</button>
+      {% if edit_row %}<a class="btn secondary" href="{{ url_for('order_tool.suppliers') }}">取消</a>{% endif %}
+    </form>
+  </section>
+
+  <section class="card span-7">
+    <h2>廠商清單</h2>
+    {% if rows %}<div class="table-scroll"><table>
+      <thead><tr><th>廠商</th><th>電話</th><th>狀態</th><th>備註</th><th>操作</th></tr></thead>
+      <tbody>{% for r in rows %}<tr>
+        <td>{{ r.name }}</td><td>{{ r.phone or '-' }}</td><td><span class="pill {{ 'ok' if r.active else 'off' }}">{{ '啟用' if r.active else '停用' }}</span></td><td>{{ r.note or '-' }}</td>
+        <td><div class="actions"><a class="btn secondary" href="{{ url_for('order_tool.suppliers', edit=r.id) }}">編輯</a>
+          <form method="post" action="{{ url_for('order_tool.supplier_toggle', supplier_id=r.id) }}"><input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"><button class="btn {{ 'danger' if r.active else 'ok' }}">{{ '停用' if r.active else '恢復' }}</button></form>
+        </div></td>
+      </tr>{% endfor %}</tbody>
+    </table></div>{% else %}<div class="empty">尚無資料。</div>{% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/tests/test_kitchen.py
+++ b/tests/test_kitchen.py
@@ -1,3 +1,4 @@
+from datetime import date
 from decimal import Decimal
 
 import pytest
@@ -11,11 +12,14 @@ from models import (
     KitchenMenuAssignment,
     KitchenMenuPlan,
     KitchenPurchaseOrder,
+    KitchenPurchaseOrderItem,
     KitchenRecipe,
     KitchenRecipeIngredient,
     KitchenSchool,
     KitchenSupplier,
 )
+
+TEST_DAY = date(2026, 8, 13)
 
 
 @pytest.fixture()
@@ -59,6 +63,16 @@ def _ids(app):
         }
 
 
+def _ids_partial(app):
+    with app.app_context():
+        school = KitchenSchool.query.filter_by(name="內小").one_or_none()
+        supplier = KitchenSupplier.query.filter_by(name="測試肉品").one_or_none()
+        return {
+            "school": school.id if school else None,
+            "supplier": supplier.id if supplier else None,
+        }
+
+
 def _seed_core_via_routes(app, client):
     assert client.post("/admin/order-tool/schools", data={"name": "內小", "code": "1-08"}).status_code == 302
     assert client.post("/admin/order-tool/suppliers", data={"name": "測試肉品", "phone": "02-12345678"}).status_code == 302
@@ -89,16 +103,6 @@ def _seed_core_via_routes(app, client):
     return ids
 
 
-def _ids_partial(app):
-    with app.app_context():
-        school = KitchenSchool.query.filter_by(name="內小").one_or_none()
-        supplier = KitchenSupplier.query.filter_by(name="測試肉品").one_or_none()
-        return {
-            "school": school.id if school else None,
-            "supplier": supplier.id if supplier else None,
-        }
-
-
 def _create_plan(app, client, ids, service_date="2026-08-13", headcount=801):
     assert client.post("/admin/order-tool/plans", data={
         "service_date": service_date,
@@ -106,8 +110,9 @@ def _create_plan(app, client, ids, service_date="2026-08-13", headcount=801):
         "name": "中央菜單",
         "note": "",
     }).status_code == 302
+    service_day = date.fromisoformat(service_date)
     with app.app_context():
-        plan = KitchenMenuPlan.query.filter_by(service_date=service_date, meal_type="午餐", name="中央菜單").one()
+        plan = KitchenMenuPlan.query.filter_by(service_date=service_day, meal_type="午餐", name="中央菜單").one()
         plan_id = plan.id
     assert client.post(f"/admin/order-tool/plans/{plan_id}/items", data={"recipe_id": str(ids["recipe"])}).status_code == 302
     assert client.post(f"/admin/order-tool/plans/{plan_id}/assignments", data={
@@ -146,7 +151,7 @@ def test_static_pages_render_and_attendance_models_survive(app, authed_client):
     assert b"kitchen_mobile.css" in response.data
 
     with app.app_context():
-        assert Employee.query.get(9001).name == "原打卡員工"
+        assert db.session.get(Employee, 9001).name == "原打卡員工"
         assert Checkin.query.filter_by(employee_id=9001).count() == 1
 
 
@@ -161,7 +166,7 @@ def test_full_801_person_purchase_calculation_and_snapshot(app, authed_client):
     assert response.status_code == 302
 
     with app.app_context():
-        order = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one()
+        order = KitchenPurchaseOrder.query.filter_by(service_date=TEST_DAY).one()
         item = order.items[0]
         assert item.required_grams == Decimal("70488.000")
         assert item.required_qty == Decimal("70.4880")
@@ -194,10 +199,9 @@ def test_full_801_person_purchase_calculation_and_snapshot(app, authed_client):
         assert item.amount == Decimal("5780.0160")
         assert db.session.get(KitchenMenuPlan, plan_id).status == "confirmed"
 
-    # 已確認的日期不可被「重新產生」偷偷覆寫。
     authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
     with app.app_context():
-        item = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one().items[0]
+        item = KitchenPurchaseOrder.query.filter_by(service_date=TEST_DAY).one().items[0]
         assert item.required_grams == Decimal("70488.000")
         assert item.unit_price_snapshot == Decimal("82.0000")
 
@@ -216,37 +220,37 @@ def test_cross_school_aggregation(app, authed_client):
     authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
 
     with app.app_context():
-        item = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one().items[0]
-        # (801 + 586) * 88g = 122,056g = 122.056kg
+        item = KitchenPurchaseOrder.query.filter_by(service_date=TEST_DAY).one().items[0]
         assert item.required_grams == Decimal("122056.000")
         assert item.required_qty == Decimal("122.0560")
 
 
 def test_supplier_grouping(app, authed_client):
     ids = _seed_core_via_routes(app, authed_client)
-    plan_id = _create_plan(app, authed_client, ids, headcount=801)
+    _create_plan(app, authed_client, ids, headcount=801)
 
     authed_client.post("/admin/order-tool/suppliers", data={"name": "測試蔬菜"})
     with app.app_context():
         veg_supplier = KitchenSupplier.query.filter_by(name="測試蔬菜").one()
+        veg_supplier_id = veg_supplier.id
     authed_client.post("/admin/order-tool/ingredients", data={
         "name": "洋芋",
-        "supplier_id": str(veg_supplier.id),
+        "supplier_id": str(veg_supplier_id),
         "purchase_unit": "kg",
         "grams_per_purchase_unit": "1000",
         "unit_price": "20",
         "order_increment": "0.001",
     })
     with app.app_context():
-        potato = KitchenIngredient.query.filter_by(name="洋芋").one()
+        potato_id = KitchenIngredient.query.filter_by(name="洋芋").one().id
     authed_client.post(f"/admin/order-tool/recipes/{ids['recipe']}/ingredients", data={
-        "ingredient_id": str(potato.id),
+        "ingredient_id": str(potato_id),
         "grams_per_person": "8",
     })
     authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
 
     with app.app_context():
-        orders = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").all()
+        orders = KitchenPurchaseOrder.query.filter_by(service_date=TEST_DAY).all()
         assert len(orders) == 2
         assert {o.supplier_name_snapshot for o in orders} == {"測試肉品", "測試蔬菜"}
         potato_order = next(o for o in orders if o.supplier_name_snapshot == "測試蔬菜")
@@ -315,12 +319,10 @@ def test_csrf_protects_kitchen_post(tmp_path):
     with client.session_transaction() as sess:
         sess["role"] = "mgr"
 
-    # 沒 token 不得新增。
     client.post("/admin/order-tool/schools", data={"name": "不該成功"})
     with app.app_context():
         assert KitchenSchool.query.filter_by(name="不該成功").first() is None
 
-    # GET 會建立 session token；帶 token 後可正常新增。
     client.get("/admin/order-tool/schools")
     with client.session_transaction() as sess:
         token = sess["_kitchen_csrf"]

--- a/tests/test_kitchen.py
+++ b/tests/test_kitchen.py
@@ -1,0 +1,353 @@
+from decimal import Decimal
+
+import pytest
+
+from app import create_app
+from extensions import db
+from models import (
+    Checkin,
+    Employee,
+    KitchenIngredient,
+    KitchenMenuAssignment,
+    KitchenMenuPlan,
+    KitchenPurchaseOrder,
+    KitchenRecipe,
+    KitchenRecipeIngredient,
+    KitchenSchool,
+    KitchenSupplier,
+)
+
+
+@pytest.fixture()
+def app(tmp_path):
+    db_path = tmp_path / "kitchen_test.db"
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "test-only-secret",
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+        "AUTO_CREATE_DB": True,
+        "KITCHEN_CSRF_ENABLED": False,
+        "ADMIN_HR_PASSWORD": "test-hr-password",
+        "ADMIN_MGR_PASSWORD": "test-mgr-password",
+        "PRODUCTION": False,
+    })
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def authed_client(client):
+    with client.session_transaction() as sess:
+        sess["role"] = "mgr"
+    return client
+
+
+def _ids(app):
+    with app.app_context():
+        return {
+            "school": KitchenSchool.query.filter_by(name="內小").one().id,
+            "supplier": KitchenSupplier.query.filter_by(name="測試肉品").one().id,
+            "ingredient": KitchenIngredient.query.filter_by(name="骨腿丁").one().id,
+            "recipe": KitchenRecipe.query.filter_by(name="南洋綠咖哩雞").one().id,
+        }
+
+
+def _seed_core_via_routes(app, client):
+    assert client.post("/admin/order-tool/schools", data={"name": "內小", "code": "1-08"}).status_code == 302
+    assert client.post("/admin/order-tool/suppliers", data={"name": "測試肉品", "phone": "02-12345678"}).status_code == 302
+    ids = _ids_partial(app)
+
+    assert client.post("/admin/order-tool/ingredients", data={
+        "name": "骨腿丁",
+        "supplier_id": str(ids["supplier"]),
+        "purchase_unit": "kg",
+        "grams_per_purchase_unit": "1000",
+        "unit_price": "82",
+        "order_increment": "0.001",
+        "note": "",
+    }).status_code == 302
+
+    assert client.post("/admin/order-tool/recipes", data={
+        "name": "南洋綠咖哩雞",
+        "category": "主菜",
+        "serving_output_g": "95",
+        "note": "",
+    }).status_code == 302
+
+    ids = _ids(app)
+    assert client.post(f"/admin/order-tool/recipes/{ids['recipe']}/ingredients", data={
+        "ingredient_id": str(ids["ingredient"]),
+        "grams_per_person": "88",
+    }).status_code == 302
+    return ids
+
+
+def _ids_partial(app):
+    with app.app_context():
+        school = KitchenSchool.query.filter_by(name="內小").one_or_none()
+        supplier = KitchenSupplier.query.filter_by(name="測試肉品").one_or_none()
+        return {
+            "school": school.id if school else None,
+            "supplier": supplier.id if supplier else None,
+        }
+
+
+def _create_plan(app, client, ids, service_date="2026-08-13", headcount=801):
+    assert client.post("/admin/order-tool/plans", data={
+        "service_date": service_date,
+        "meal_type": "午餐",
+        "name": "中央菜單",
+        "note": "",
+    }).status_code == 302
+    with app.app_context():
+        plan = KitchenMenuPlan.query.filter_by(service_date=service_date, meal_type="午餐", name="中央菜單").one()
+        plan_id = plan.id
+    assert client.post(f"/admin/order-tool/plans/{plan_id}/items", data={"recipe_id": str(ids["recipe"])}).status_code == 302
+    assert client.post(f"/admin/order-tool/plans/{plan_id}/assignments", data={
+        "school_id": str(ids["school"]),
+        "headcount": str(headcount),
+    }).status_code == 302
+    return plan_id
+
+
+def test_kitchen_requires_login(client):
+    response = client.get("/admin/order-tool/", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/admin/login" in response.headers["Location"]
+
+
+def test_static_pages_render_and_attendance_models_survive(app, authed_client):
+    with app.app_context():
+        db.session.add(Employee(id=9001, name="原打卡員工", area="A", default_break=0.5))
+        db.session.add(Checkin(employee_id=9001, work_date="2026-08-13", p_type="in", ts="2026-08-13 08:00:00"))
+        db.session.commit()
+
+    for path in (
+        "/admin/order-tool/",
+        "/admin/order-tool/schools",
+        "/admin/order-tool/suppliers",
+        "/admin/order-tool/ingredients",
+        "/admin/order-tool/recipes",
+        "/admin/order-tool/plans",
+        "/admin/order-tool/purchases",
+        "/admin/order-tool/purchase",
+    ):
+        response = authed_client.get(path)
+        assert response.status_code in (200, 302), path
+
+    response = authed_client.get("/admin/order-tool/")
+    assert b"kitchen_mobile.css" in response.data
+
+    with app.app_context():
+        assert Employee.query.get(9001).name == "原打卡員工"
+        assert Checkin.query.filter_by(employee_id=9001).count() == 1
+
+
+def test_full_801_person_purchase_calculation_and_snapshot(app, authed_client):
+    ids = _seed_core_via_routes(app, authed_client)
+    plan_id = _create_plan(app, authed_client, ids, headcount=801)
+
+    response = authed_client.post("/admin/order-tool/purchases/generate", data={
+        "start": "2026-08-13",
+        "end": "2026-08-13",
+    })
+    assert response.status_code == 302
+
+    with app.app_context():
+        order = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one()
+        item = order.items[0]
+        assert item.required_grams == Decimal("70488.000")
+        assert item.required_qty == Decimal("70.4880")
+        assert item.recommended_order_qty == Decimal("70.4880")
+        assert item.actual_order_qty == Decimal("70.4880")
+        assert item.unit_price_snapshot == Decimal("82.0000")
+        assert item.amount == Decimal("5780.0160")
+        order_id = order.id
+
+    detail = authed_client.get(f"/admin/order-tool/purchases/{order_id}")
+    assert detail.status_code == 200
+    assert b"70.488" in detail.data
+    assert b"5780.02" in detail.data
+
+    assert authed_client.post(f"/admin/order-tool/purchases/{order_id}/confirm").status_code == 302
+
+    # 修改 master data 後，已確認歷史採購單必須保持原 snapshot。
+    with app.app_context():
+        ingredient = db.session.get(KitchenIngredient, ids["ingredient"])
+        ingredient.unit_price = Decimal("90")
+        component = KitchenRecipeIngredient.query.filter_by(recipe_id=ids["recipe"], ingredient_id=ids["ingredient"]).one()
+        component.grams_per_person = Decimal("90")
+        db.session.commit()
+
+        order = db.session.get(KitchenPurchaseOrder, order_id)
+        item = order.items[0]
+        assert order.status == "confirmed"
+        assert item.required_grams == Decimal("70488.000")
+        assert item.unit_price_snapshot == Decimal("82.0000")
+        assert item.amount == Decimal("5780.0160")
+        assert db.session.get(KitchenMenuPlan, plan_id).status == "confirmed"
+
+    # 已確認的日期不可被「重新產生」偷偷覆寫。
+    authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+    with app.app_context():
+        item = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one().items[0]
+        assert item.required_grams == Decimal("70488.000")
+        assert item.unit_price_snapshot == Decimal("82.0000")
+
+
+def test_cross_school_aggregation(app, authed_client):
+    ids = _seed_core_via_routes(app, authed_client)
+    plan_id = _create_plan(app, authed_client, ids, headcount=801)
+
+    authed_client.post("/admin/order-tool/schools", data={"name": "文山", "code": "1-21"})
+    with app.app_context():
+        second_school_id = KitchenSchool.query.filter_by(name="文山").one().id
+    authed_client.post(f"/admin/order-tool/plans/{plan_id}/assignments", data={
+        "school_id": str(second_school_id),
+        "headcount": "586",
+    })
+    authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+
+    with app.app_context():
+        item = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").one().items[0]
+        # (801 + 586) * 88g = 122,056g = 122.056kg
+        assert item.required_grams == Decimal("122056.000")
+        assert item.required_qty == Decimal("122.0560")
+
+
+def test_supplier_grouping(app, authed_client):
+    ids = _seed_core_via_routes(app, authed_client)
+    plan_id = _create_plan(app, authed_client, ids, headcount=801)
+
+    authed_client.post("/admin/order-tool/suppliers", data={"name": "測試蔬菜"})
+    with app.app_context():
+        veg_supplier = KitchenSupplier.query.filter_by(name="測試蔬菜").one()
+    authed_client.post("/admin/order-tool/ingredients", data={
+        "name": "洋芋",
+        "supplier_id": str(veg_supplier.id),
+        "purchase_unit": "kg",
+        "grams_per_purchase_unit": "1000",
+        "unit_price": "20",
+        "order_increment": "0.001",
+    })
+    with app.app_context():
+        potato = KitchenIngredient.query.filter_by(name="洋芋").one()
+    authed_client.post(f"/admin/order-tool/recipes/{ids['recipe']}/ingredients", data={
+        "ingredient_id": str(potato.id),
+        "grams_per_person": "8",
+    })
+    authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+
+    with app.app_context():
+        orders = KitchenPurchaseOrder.query.filter_by(service_date="2026-08-13").all()
+        assert len(orders) == 2
+        assert {o.supplier_name_snapshot for o in orders} == {"測試肉品", "測試蔬菜"}
+        potato_order = next(o for o in orders if o.supplier_name_snapshot == "測試蔬菜")
+        assert potato_order.items[0].required_grams == Decimal("6408.000")
+
+
+def test_actual_purchase_qty_and_price_are_persisted(app, authed_client):
+    ids = _seed_core_via_routes(app, authed_client)
+    _create_plan(app, authed_client, ids)
+    authed_client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+
+    with app.app_context():
+        order = KitchenPurchaseOrder.query.one()
+        item = order.items[0]
+        order_id, item_id = order.id, item.id
+
+    authed_client.post(f"/admin/order-tool/purchase-items/{item_id}/update", data={
+        "actual_order_qty": "72",
+        "unit_price": "83.5",
+        "note": "人工調整",
+    })
+
+    with app.app_context():
+        item = db.session.get(KitchenPurchaseOrderItem, item_id)
+        assert item.actual_order_qty == Decimal("72.0000")
+        assert item.unit_price_snapshot == Decimal("83.5000")
+        assert item.amount == Decimal("6012.0000")
+        assert item.note == "人工調整"
+        assert db.session.get(KitchenPurchaseOrder, order_id).status == "draft"
+
+
+def test_invalid_negative_values_do_not_mutate(app, authed_client):
+    ids = _seed_core_via_routes(app, authed_client)
+    plan_id = _create_plan(app, authed_client, ids, headcount=801)
+    with app.app_context():
+        assignment = KitchenMenuAssignment.query.filter_by(plan_id=plan_id, school_id=ids["school"]).one()
+        assignment_id = assignment.id
+
+    authed_client.post(f"/admin/order-tool/assignments/{assignment_id}/update", data={"headcount": "-5"})
+    with app.app_context():
+        assert db.session.get(KitchenMenuAssignment, assignment_id).headcount == 801
+
+    response = authed_client.post("/admin/order-tool/ingredients", data={
+        "name": "錯誤食材",
+        "purchase_unit": "kg",
+        "grams_per_purchase_unit": "1000",
+        "unit_price": "-1",
+        "order_increment": "0.001",
+    })
+    assert response.status_code == 302
+    with app.app_context():
+        assert KitchenIngredient.query.filter_by(name="錯誤食材").first() is None
+
+
+def test_csrf_protects_kitchen_post(tmp_path):
+    db_path = tmp_path / "csrf.db"
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "csrf-test-secret",
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+        "AUTO_CREATE_DB": True,
+        "KITCHEN_CSRF_ENABLED": True,
+        "PRODUCTION": False,
+    })
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["role"] = "mgr"
+
+    # 沒 token 不得新增。
+    client.post("/admin/order-tool/schools", data={"name": "不該成功"})
+    with app.app_context():
+        assert KitchenSchool.query.filter_by(name="不該成功").first() is None
+
+    # GET 會建立 session token；帶 token 後可正常新增。
+    client.get("/admin/order-tool/schools")
+    with client.session_transaction() as sess:
+        token = sess["_kitchen_csrf"]
+    client.post("/admin/order-tool/schools", data={"name": "合法學校", "_csrf_token": token})
+    with app.app_context():
+        assert KitchenSchool.query.filter_by(name="合法學校").one()
+        db.drop_all()
+
+
+def test_file_sqlite_persists_across_app_restart(tmp_path):
+    db_path = tmp_path / "restart.db"
+    uri = f"sqlite:///{db_path}"
+    config = {
+        "TESTING": True,
+        "SECRET_KEY": "restart-test",
+        "SQLALCHEMY_DATABASE_URI": uri,
+        "AUTO_CREATE_DB": True,
+        "KITCHEN_CSRF_ENABLED": False,
+        "PRODUCTION": False,
+    }
+    app1 = create_app(config)
+    with app1.app_context():
+        db.session.add(KitchenSchool(name="重啟後還在"))
+        db.session.commit()
+        db.session.remove()
+
+    app2 = create_app({**config, "AUTO_CREATE_DB": False})
+    with app2.app_context():
+        assert KitchenSchool.query.filter_by(name="重啟後還在").one()
+        db.drop_all()

--- a/tests/test_kitchen_guardrails.py
+++ b/tests/test_kitchen_guardrails.py
@@ -1,0 +1,150 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app import create_app
+from extensions import db
+from models import (
+    KitchenIngredient,
+    KitchenMenuAssignment,
+    KitchenMenuPlan,
+    KitchenPurchaseOrder,
+    KitchenRecipe,
+    KitchenRecipeIngredient,
+    KitchenSchool,
+    KitchenSupplier,
+)
+
+
+@pytest.fixture()
+def app(tmp_path):
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "guardrail-test",
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'guardrail.db'}",
+        "AUTO_CREATE_DB": True,
+        "KITCHEN_CSRF_ENABLED": False,
+        "PRODUCTION": False,
+    })
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["role"] = "mgr"
+    return client
+
+
+def _seed_g_recipe(app, client, service_date="2026-08-13"):
+    client.post("/admin/order-tool/schools", data={"name": "內小"})
+    client.post("/admin/order-tool/suppliers", data={"name": "測試肉品"})
+    with app.app_context():
+        school = KitchenSchool.query.filter_by(name="內小").one()
+        supplier = KitchenSupplier.query.filter_by(name="測試肉品").one()
+        school_id, supplier_id = school.id, supplier.id
+
+    client.post("/admin/order-tool/ingredients", data={
+        "name": "骨腿丁", "supplier_id": supplier_id, "base_unit": "g",
+        "purchase_unit": "kg", "grams_per_purchase_unit": "1000",
+        "unit_price": "82", "order_increment": "0.001",
+    })
+    client.post("/admin/order-tool/recipes", data={"name": "南洋綠咖哩雞", "category": "主菜", "serving_output_g": "95"})
+    with app.app_context():
+        ingredient = KitchenIngredient.query.filter_by(name="骨腿丁").one()
+        recipe = KitchenRecipe.query.filter_by(name="南洋綠咖哩雞").one()
+        ingredient_id, recipe_id = ingredient.id, recipe.id
+
+    client.post(f"/admin/order-tool/recipes/{recipe_id}/ingredients", data={"ingredient_id": ingredient_id, "grams_per_person": "88"})
+    client.post("/admin/order-tool/plans", data={"service_date": service_date, "meal_type": "午餐", "name": "中央菜單"})
+    with app.app_context():
+        plan = KitchenMenuPlan.query.filter_by(service_date=date.fromisoformat(service_date), name="中央菜單").one()
+        plan_id = plan.id
+    client.post(f"/admin/order-tool/plans/{plan_id}/items", data={"recipe_id": recipe_id})
+    client.post(f"/admin/order-tool/plans/{plan_id}/assignments", data={"school_id": school_id, "headcount": "801"})
+    return {"school": school_id, "supplier": supplier_id, "ingredient": ingredient_id, "recipe": recipe_id, "plan": plan_id}
+
+
+def test_piece_based_recipe_calculates_boxes(app, client):
+    client.post("/admin/order-tool/schools", data={"name": "內小"})
+    client.post("/admin/order-tool/suppliers", data={"name": "雞肉商"})
+    with app.app_context():
+        school_id = KitchenSchool.query.filter_by(name="內小").one().id
+        supplier_id = KitchenSupplier.query.filter_by(name="雞肉商").one().id
+
+    client.post("/admin/order-tool/ingredients", data={
+        "name": "棒棒腿", "supplier_id": supplier_id, "base_unit": "個",
+        "purchase_unit": "箱", "grams_per_purchase_unit": "50",
+        "unit_price": "1000", "order_increment": "1",
+    })
+    client.post("/admin/order-tool/recipes", data={"name": "炸棒棒腿", "category": "主菜"})
+    with app.app_context():
+        ingredient_id = KitchenIngredient.query.filter_by(name="棒棒腿").one().id
+        recipe_id = KitchenRecipe.query.filter_by(name="炸棒棒腿").one().id
+
+    client.post(f"/admin/order-tool/recipes/{recipe_id}/ingredients", data={"ingredient_id": ingredient_id, "grams_per_person": "1"})
+    client.post("/admin/order-tool/plans", data={"service_date": "2026-08-14", "meal_type": "午餐", "name": "中央菜單"})
+    with app.app_context():
+        plan_id = KitchenMenuPlan.query.filter_by(service_date=date(2026, 8, 14)).one().id
+    client.post(f"/admin/order-tool/plans/{plan_id}/items", data={"recipe_id": recipe_id})
+    client.post(f"/admin/order-tool/plans/{plan_id}/assignments", data={"school_id": school_id, "headcount": "801"})
+    client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-14", "end": "2026-08-14"})
+
+    with app.app_context():
+        item = KitchenPurchaseOrder.query.filter_by(service_date=date(2026, 8, 14)).one().items[0]
+        assert item.base_unit_snapshot == "個"
+        assert item.required_grams == Decimal("801.000")
+        assert item.required_qty == Decimal("16.0200")
+        assert item.recommended_order_qty == Decimal("17.0000")
+        assert item.actual_order_qty == Decimal("17.0000")
+        assert item.amount == Decimal("17000.0000")
+
+
+def test_same_school_same_day_same_meal_cannot_be_double_assigned(app, client):
+    ids = _seed_g_recipe(app, client)
+    client.post("/admin/order-tool/plans", data={"service_date": "2026-08-13", "meal_type": "午餐", "name": "第二張菜單"})
+    with app.app_context():
+        second = KitchenMenuPlan.query.filter_by(service_date=date(2026, 8, 13), name="第二張菜單").one()
+        second_id = second.id
+    client.post(f"/admin/order-tool/plans/{second_id}/assignments", data={"school_id": ids["school"], "headcount": "801"})
+
+    with app.app_context():
+        count = (
+            KitchenMenuAssignment.query.join(KitchenMenuPlan)
+            .filter(
+                KitchenMenuAssignment.school_id == ids["school"],
+                KitchenMenuPlan.service_date == date(2026, 8, 13),
+                KitchenMenuPlan.meal_type == "午餐",
+            ).count()
+        )
+        assert count == 1
+
+
+def test_manual_purchase_override_survives_regeneration(app, client):
+    _seed_g_recipe(app, client)
+    client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+    with app.app_context():
+        order = KitchenPurchaseOrder.query.one()
+        item = order.items[0]
+        item_id = item.id
+
+    client.post(f"/admin/order-tool/purchase-items/{item_id}/update", data={
+        "actual_order_qty": "72", "unit_price": "83.5", "note": "人工調整",
+    })
+    client.post("/admin/order-tool/purchases/generate", data={"start": "2026-08-13", "end": "2026-08-13"})
+
+    with app.app_context():
+        order = KitchenPurchaseOrder.query.one()
+        item = order.items[0]
+        assert item.id == item_id
+        assert item.required_qty == Decimal("70.4880")
+        assert item.recommended_order_qty == Decimal("70.4880")
+        assert item.actual_order_qty == Decimal("72.0000")
+        assert item.unit_price_snapshot == Decimal("83.5000")
+        assert item.amount == Decimal("6012.0000")
+        assert item.note == "人工調整"
+        assert item.manual_override is True


### PR DESCRIPTION
將原本 /admin/order-tool 的 Excel 篩選器升級為可實際保存資料的團膳管理候選版；目前仍為 Draft，禁止自動 merge main。

已完成：
- 保留既有 Employee / Checkin 與 /punch 流程
- School / Supplier / Ingredient / Recipe 完整新增、編輯、停用
- Recipe BOM 以每人 AP 克數儲存；打菜量另存、不參與採購計算
- 食材支援 kg / 箱 / 包 / 斤 / 瓶 / 個 / 袋 / 桶、每單位克數、價格、最小叫貨增量
- 中央菜單、菜色、學校人數、複製菜單、確認/重開草稿
- 正式 KitchenPurchaseOrder / KitchenPurchaseOrderItem persistence
- 需求量、建議叫貨量、實際叫貨量分開保存
- Confirm 後 snapshot 鎖定，不受後續 master price / recipe 修改影響
- 依供應商分單、採購歷史、列印/另存 PDF
- 手機/平板/桌機 responsive UI；kitchen CSS/JS 不污染 attendance UI
- /admin 登入保護、環境變數密碼/SECRET_KEY、kitchen POST CSRF、production fail-closed
- kitchen-only migration 與 Supabase 安全部署說明
- pytest regression tests：801人=70.488kg、成本5780.016、跨學校加總、供應商拆單、snapshot、persistence、CSRF、invalid input

上線前仍必須由 Codex/瀏覽器實際執行：
1. python compileall
2. pytest -q tests/test_kitchen.py
3. 375×812 / 430×932 / 768×1024 / 1440×900 UI 截圖驗收
4. staging Supabase schema/migration 驗證
5. 原打卡流程 regression check

部署注意事項見 KITCHEN_DEPLOY.md。

不要 merge main，直到上述驗收全部通過。